### PR TITLE
ci: add Dependabot config for npm and github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 5
     groups:
       types:
         patterns:
@@ -15,9 +15,11 @@ updates:
       production-dependencies:
         dependency-type: "production"
     commit-message:
+      # No `include: "scope"` — it would duplicate the type in the
+      # prefix ("deps(deps): …" / "deps-dev(deps-dev): …") since we
+      # already encode prod vs dev in `prefix` / `prefix-development`.
       prefix: "deps"
       prefix-development: "deps-dev"
-      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,28 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "npm"
+    directory: "/"
     schedule:
       interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 10
+    groups:
+      types:
+        patterns:
+          - "@types/*"
+      dev-dependencies:
+        dependency-type: "development"
+      production-dependencies:
+        dependency-type: "production"
+    commit-message:
+      prefix: "deps"
+      prefix-development: "deps-dev"
+      include: "scope"
 
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "ci"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,14 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 5
+    # Keep @types/node pinned on the 20.x line so its type surface
+    # tracks engines.node (>=20.11). A semver-major bump would declare
+    # APIs the runtime doesn't guarantee. Reopen only when we move the
+    # engines floor to a newer LTS.
+    ignore:
+      - dependency-name: "@types/node"
+        update-types:
+          - "version-update:semver-major"
     groups:
       types:
         patterns:
@@ -26,5 +34,6 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
+    open-pull-requests-limit: 5
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` configuring weekly dependency updates for the `npm` and `github-actions` ecosystems.

## Details

- **npm updates** (weekly, Monday) with grouping into three buckets:
  - `types` — all `@types/*` packages
  - `dev-dependencies` — every `devDependency` that isn't a type
  - `production-dependencies` — every runtime `dependency`
- **github-actions updates** (weekly, Monday) — keeps every SHA-pinned action current.
- Commit-message prefixes: `deps` (prod), `deps-dev` (dev), `ci` (actions). `include: "scope"` is intentionally NOT set — it duplicates the type marker and produces titles like `deps(deps): …` (see discussion on faxdrop and mercury where we fixed the same foot-gun).
- `open-pull-requests-limit: 5` on the npm stream — keeps the review queue from drowning in a single weekly cycle.
- `@types/node` major bumps are ignored (the project's Node floor is 20.11; jumping type definitions to 24.x+ would declare APIs the runtime does not guarantee).