### PR TITLE
chore: add CodeRabbit config aligned with klodr MCP policy

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -5,7 +5,7 @@ language: en-US
 early_access: false
 
 reviews:
-  profile: chill              # lighter feedback (vs "assertive")
+  profile: assertive          # stricter feedback (vs "chill")
   request_changes_workflow: true
   high_level_summary: true
   high_level_summary_in_walkthrough: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,75 @@
+# CodeRabbit configuration
+# Docs: https://docs.coderabbit.ai/guides/configure-coderabbit
+
+language: en-US
+early_access: false
+
+reviews:
+  profile: chill              # lighter feedback (vs "assertive")
+  request_changes_workflow: true
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  poem: false                 # no decorative poetry
+  review_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  auto_apply_labels: true
+  abort_on_close: true
+
+  auto_title_instructions: |
+    Use conventional commit format: type(scope): description.
+    Types: feat, fix, docs, ci, chore, refactor, test, perf.
+    Keep under 72 chars.
+
+  high_level_summary_instructions: |
+    Concise bullet-point list of user-facing changes.
+    Focus on security, OAuth scopes, and tool behavior.
+    Skip internal refactors.
+
+  auto_review:
+    enabled: true
+    drafts: false
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    base_branches:
+      - main
+
+  pre_merge_checks:
+    docstrings:
+      # The codebase deliberately keeps comments to non-obvious WHY only.
+      # MCP tool descriptions live in Zod .describe() calls, not JSDoc.
+      mode: off
+
+  path_instructions:
+    - path: "src/tools.ts"
+      instructions: |
+        MCP tool registry and Zod schemas. Verify:
+        - Zod schemas enforce bounds (maxResults, batchSize have .max())
+        - File-path inputs (attachments, savePath) are constrained
+        - Tool `scopes` field matches the Gmail API scope actually required
+        - destructiveHint / readOnlyHint annotations reflect real behavior
+    - path: "src/scopes.ts"
+      instructions: |
+        OAuth scope mapping. Flag any change that:
+        - Widens the default scope list (DEFAULT_SCOPES)
+        - Loosens scope validation
+        - Breaks shorthand↔URL round-trip
+    - path: "src/utl.ts"
+      instructions: |
+        Security-sensitive email construction.
+        Flag any regression on CRLF sanitization, attachment path validation,
+        or cryptographic boundary generation.
+    - path: "src/index.ts"
+      instructions: |
+        Main entry point with OAuth flow and tool handlers.
+        Verify savePath / filePath inputs are validated before fs operations.
+        Stdout must stay clean (JSON-RPC only — use console.error for logs).
+
+chat:
+  auto_reply: true


### PR DESCRIPTION
Adds `.coderabbit.yaml` aligned with the klodr MCP review policy (same pattern as faxdrop-mcp and mercury-invoicing-mcp, adapted for gmail-mcp).

## Key settings

- **`profile: chill`** — lighter feedback; we already have CodeQL + Socket + Snyk covering security/deps
- **`request_changes_workflow: true`** — enables `@coderabbitai resolve` / `@coderabbitai approve` top-level commands (needed to dismiss false positives like markdownlint-cli2's MD031 on indented fences inside list items)
- **`high_level_summary_in_walkthrough: true`** — keeps PR descriptions author-controlled
- **`sequence_diagrams: true`** — useful on an MCP that proxies between LLM and Gmail API
- **Auto title:** conventional commit format with 72-char cap
- **`pre_merge_checks.docstrings: off`** — MCP tool descriptions already live in Zod `.describe()` calls; JSDoc would duplicate

## Path-specific review rules

- `src/tools.ts` — verify Zod bounds, file-path constraints, scope↔tool alignment
- `src/scopes.ts` — flag any widening of `DEFAULT_SCOPES` or scope validation loosening
- `src/utl.ts` — security-sensitive email construction (CRLF sanitization, attachment paths, crypto boundaries)
- `src/index.ts` — validate savePath/filePath before fs ops; stdout must stay JSON-RPC clean