### PR TITLE
docs: add security warning — not independently reviewed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # Gmail AutoAuth MCP Server (Actively Maintained Fork)
 
+> [!WARNING]
+> **This repository has not been independently security-reviewed and is not recommended for production use in its current state.** A security audit is in progress. Use at your own risk.
+
 [![CI](https://github.com/ArtyMcLabin/Gmail-MCP-Server/actions/workflows/ci.yml/badge.svg)](https://github.com/ArtyMcLabin/Gmail-MCP-Server/actions/workflows/ci.yml)
 
 > **This is an actively maintained fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server).**


### PR DESCRIPTION
Adds a `> [!WARNING]` callout at the top of the README making it obvious that this fork has **not** been independently security-reviewed yet. Without this, a user glancing at the repo could assume the same security posture as the klodr/faxdrop-mcp and klodr/mercury-invoicing-mcp siblings.

The warning will be removed once the in-progress audit completes.

Same content as the warning already in PR #7 — extracted here as a standalone PR so it can land on main immediately (PR #7 is blocked on the CI-runner deadlock).