### PR TITLE
chore: CODEOWNERS + issue/PR templates

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,21 @@
+# CODEOWNERS — GitHub auto-requests review from these handles when a
+# matching path changes. Reference: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+#
+# The project is currently maintained by a single individual. This file
+# documents that reality explicitly so reviewers and contributors know
+# who is accountable for each surface, and creates an obvious drop-in
+# point when a second maintainer joins (the "Second maintainer → OpenSSF
+# Gold" item on the ROADMAP).
+
+# Default owner for everything in the repo
+*                                   @klodr
+
+# Security-sensitive surfaces — any future co-maintainer added here
+# would also need explicit security review on PRs touching these paths.
+/SECURITY.md                        @klodr
+/ASSURANCE_CASE.md                  @klodr
+/src/utl.ts                         @klodr
+/src/gmail-errors.ts                @klodr
+/.github/workflows/                 @klodr
+/.github/dependabot.yml             @klodr
+/socket.yml                         @klodr

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,93 @@
+name: Bug report
+description: Something is not working as expected in the MCP server.
+labels: ["bug", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. Before you submit, please
+        make sure the report does not contain any secrets
+        (`gcp-oauth.keys.json`, `credentials.json`, OAuth refresh tokens,
+        message bodies). Redact them if they appear in your logs or config
+        snippets.
+
+        Security vulnerabilities — DO NOT file them here. Report privately
+        at https://github.com/klodr/gmail-mcp/security/advisories/new.
+
+  - type: input
+    id: version
+    attributes:
+      label: MCP server version
+      description: "Output of `npx @klodr/gmail-mcp --version` or the version in your `package.json`."
+      placeholder: "e.g. 0.1.0"
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node.js version
+      description: "Output of `node --version`. The project requires ≥ 20.11."
+      placeholder: "e.g. v20.11.1"
+    validations:
+      required: true
+
+  - type: input
+    id: client
+    attributes:
+      label: MCP client
+      description: "Which client is consuming the server?"
+      placeholder: "e.g. Claude Desktop 0.7, Claude Code, Cursor, Continue, OpenClaw…"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scopes
+    attributes:
+      label: OAuth scopes granted
+      description: "From the `auth` step — check all that apply."
+      multiple: true
+      options:
+        - gmail.readonly
+        - gmail.modify
+        - gmail.compose
+        - gmail.send
+        - gmail.labels
+        - gmail.settings.basic
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected to happen
+      placeholder: "e.g. calling `send_email` with a valid attachment path returns a message ID."
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What actually happened
+      description: Include the exact error message if there is one.
+      render: text
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Exact tool call payload or shell command, with secrets redacted.
+      render: json
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: stderr output from the MCP server or the MCP client's console. Redact any OAuth tokens.
+      render: text
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/klodr/gmail-mcp/security/advisories/new
+    about: Do NOT open a public issue for security findings. Use the private advisory channel — the maintainer acknowledges within 48h.
+  - name: Install guide for AI agents
+    url: https://github.com/klodr/gmail-mcp/blob/main/llms-install.md
+    about: Before filing a setup bug, make sure the LLM-readable install guide was followed.
+  - name: Scope / OAuth question
+    url: https://github.com/klodr/gmail-mcp#oauth-scopes
+    about: The README documents which tools each Gmail scope unlocks.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,54 @@
+name: Feature request
+description: Propose a new tool, option, or behaviour for the MCP server.
+labels: ["enhancement", "triage"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Feature proposals should map to the Gmail API surface or to the
+        MCP safeguards (jails, scope filtering, rate limits, audit log).
+        For broader direction questions, check `ROADMAP.md` first — the
+        item may already be scheduled or explicitly out-of-scope.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: The user / agent need, not the proposed solution.
+      placeholder: "e.g. an agent needs to programmatically enable/disable Gmail's auto-responder."
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed tool / behaviour
+      description: If this introduces a new MCP tool, sketch the input/output Zod schema + required OAuth scope. Link the matching Gmail API reference.
+      placeholder: |
+        Tool name: `get_vacation_responder`
+        Scope: gmail.settings.basic
+        Gmail API: users.settings.getVacation (https://…)
+        Input: {}
+        Output: { enabled: boolean, subject?: string, bodyPlainText?: string, ... }
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: "e.g. could this already be done with an existing tool + extra prompt context?"
+    validations:
+      required: false
+
+  - type: dropdown
+    id: destructive
+    attributes:
+      label: Is this destructive?
+      description: Does the proposed tool send mail, delete data, or modify Gmail settings?
+      options:
+        - No — read only
+        - Yes — but idempotent (e.g. apply a label)
+        - Yes — non-idempotent (e.g. send_email, delete_message)
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+## Summary
+
+<!-- 1-3 bullets describing what this PR changes and WHY. Link the
+     issue / CodeRabbit finding / ROADMAP entry if applicable. -->
+
+## Type
+
+<!-- Check all that apply. -->
+
+- [ ] `feat` — new user-facing feature or tool
+- [ ] `fix` — bug fix
+- [ ] `docs` — documentation only
+- [ ] `refactor` — no behaviour change
+- [ ] `perf` — performance
+- [ ] `test` — test-only change
+- [ ] `ci` — CI / workflows / release plumbing
+- [ ] `chore` — deps, build, or other repo-management
+- [ ] `security` — security-sensitive change (see Security checklist below)
+
+## Checklist
+
+- [ ] `npm test` green locally (vitest)
+- [ ] `npm run build` succeeds (includes `tsc --noEmit`)
+- [ ] `npm run lint` clean
+- [ ] `npm run format:check` clean
+- [ ] `CHANGELOG.md` updated under `[Unreleased]` (if user-visible)
+- [ ] Conventional-commit PR title ≤72 chars
+
+## Security checklist (only if you ticked `security` above)
+
+- [ ] Threat model in `ASSURANCE_CASE.md` still accurate after this change — or has been updated
+- [ ] New file-system writes routed through `resolveDownloadSavePath()` or `assertAttachmentPathAllowed()` (`src/utl.ts`)
+- [ ] New user-supplied RFC-822 header values passed through `sanitizeHeaderValue()`
+- [ ] New Zod input schema has `.max()` bounds on any unbounded field
+- [ ] Tool registered in `src/tools.ts` with correct `scopes` + `readOnlyHint` / `destructiveHint` / `idempotentHint`
+
+## Notes for reviewers
+
+<!-- Anything non-obvious about the implementation, edge cases deliberately
+     not covered, or follow-up work that belongs in a separate PR. -->


### PR DESCRIPTION
## Summary

Split out of #16 — CODEOWNERS + issue/PR templates only.

- `.github/CODEOWNERS`: default owner @klodr, explicit fences on security-sensitive surfaces (SECURITY.md, ASSURANCE_CASE.md, src/utl.ts, src/gmail-errors.ts, workflows, dependabot, socket).
- `.github/pull_request_template.md`: conventional-commit typing checkbox, standard CI gates, changelog reminder, security sub-checklist.
- `.github/ISSUE_TEMPLATE/`: bug_report.yml, feature_request.yml, config.yml.

## Test plan

- [x] Templates + CODEOWNERS syntax validated