### PR TITLE
test: fast-check fuzz suite + CodeQL cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
+        "fast-check": "^4.7.0",
         "prettier": "^3.8.3",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",
@@ -2952,6 +2953,29 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/fast-check": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.7.0.tgz",
+      "integrity": "sha512-NsZRtqvSSoCP0HbNjUD+r1JH8zqZalyp6gLY9e7OYs7NK9b6AHOs2baBFeBG7bVNsuoukh89x2Yg3rPsul8ziQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4587,6 +4611,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.0.tgz",
+      "integrity": "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/qs": {
       "version": "6.15.1",

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
+    "fast-check": "^4.7.0",
     "prettier": "^3.8.3",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",

--- a/src/download-email.test.ts
+++ b/src/download-email.test.ts
@@ -18,7 +18,7 @@ import {
   parseEmailAddress,
   parseEmailAddresses,
 } from "./email-export.js";
-import { toolDefinitions, getToolByName, DownloadEmailSchema } from "./tools.js";
+import { getToolByName, DownloadEmailSchema } from "./tools.js";
 import { hasScope } from "./scopes.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/src/reply-all-helpers.ts
+++ b/src/reply-all-helpers.ts
@@ -42,14 +42,19 @@ export function parseEmailAddresses(headerValue: string): string[] {
   const emails: string[] = [];
   for (const part of parts) {
     const trimmed = part.trim();
-    // Extract email from "Name <email>" format
-    const match = trimmed.match(/<([^>]+)>/);
-    if (match?.[1]) {
-      // Only accept the extracted angle-bracket content if it is
-      // actually an address shape (contains '@'). Fast-check found
-      // '< >' — empty inside the brackets — silently pushing as "".
-      const inside = match[1].trim();
-      if (inside.includes("@")) emails.push(inside);
+    // Extract email from "Name <email>" format. Three traps guarded
+    // against, all surfaced by the fast-check fuzzer:
+    //   1. A display name that itself contains a '<…>' span (must
+    //      pick the LAST bracketed address, not the first — so a
+    //      `"Display <alias@meta>" <real@host>` returns `real@host`).
+    //   2. Empty `< >` — skipped by the `@` requirement inside the
+    //      brackets.
+    //   3. Nested '<' or '>' — excluded from the capture class
+    //      (`[^<>]`) so the regex anchors to a single bracketed span.
+    const bracketMatches = [...trimmed.matchAll(/<([^<>]*@[^<>]*)>/g)];
+    const lastBracketEmail = bracketMatches.at(-1)?.[1]?.trim();
+    if (lastBracketEmail) {
+      emails.push(lastBracketEmail);
     } else if (trimmed.includes("@")) {
       // Strip any surrounding quotes / whitespace from a bare address
       emails.push(trimmed.replace(/^["']|["']$/g, "").trim());

--- a/src/reply-all-helpers.ts
+++ b/src/reply-all-helpers.ts
@@ -45,7 +45,11 @@ export function parseEmailAddresses(headerValue: string): string[] {
     // Extract email from "Name <email>" format
     const match = trimmed.match(/<([^>]+)>/);
     if (match?.[1]) {
-      emails.push(match[1].trim());
+      // Only accept the extracted angle-bracket content if it is
+      // actually an address shape (contains '@'). Fast-check found
+      // '< >' — empty inside the brackets — silently pushing as "".
+      const inside = match[1].trim();
+      if (inside.includes("@")) emails.push(inside);
     } else if (trimmed.includes("@")) {
       // Strip any surrounding quotes / whitespace from a bare address
       emails.push(trimmed.replace(/^["']|["']$/g, "").trim());

--- a/src/utl.ts
+++ b/src/utl.ts
@@ -221,8 +221,10 @@ export const validateEmail = (email: string): boolean => {
 /**
  * Sanitize a value destined for an email header to prevent CRLF injection.
  * Strips \r, \n, and \0 characters that could inject additional headers.
+ * Exported so test/fuzz.test.ts can fuzz the real implementation instead
+ * of a drift-prone mirror.
  */
-function sanitizeHeaderValue(value: string): string {
+export function sanitizeHeaderValue(value: string): string {
   return value.replace(/[\r\n\0]/g, "");
 }
 

--- a/test/fuzz.test.ts
+++ b/test/fuzz.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Property-based (fuzz) tests for security-sensitive helpers.
+ * Uses fast-check, recognised by OpenSSF Scorecard's Fuzzing check
+ * for the JS/TS ecosystem.
+ *
+ * Targets:
+ * - `sanitizeHeaderValue` (re-implemented locally, since utl.ts keeps
+ *   the function un-exported): the property we care about is that
+ *   the output never contains `\r`, `\n`, or `\0` no matter what the
+ *   input is. If a future refactor ever exports a new sanitizer, swap
+ *   the local copy for the real one here.
+ * - `createEmailMessage`: no user-supplied header value ever survives
+ *   as a raw CRLF in the output header block, for any subject /
+ *   inReplyTo / references / from / cc / bcc.
+ * - `parseEmailAddresses`: always returns an array of `@`-containing
+ *   strings, never throws, regardless of quote state or commas.
+ */
+
+import { describe, it, expect } from "vitest";
+import * as fc from "fast-check";
+import { createEmailMessage } from "../src/utl.js";
+import { parseEmailAddresses } from "../src/reply-all-helpers.js";
+
+// Mirror the strip pattern used in src/utl.ts#sanitizeHeaderValue so
+// the property is independently testable. A drift here would surface
+// as either a test failure (good) or a too-permissive property (bad) —
+// kept in sync manually; revisit if utl.ts exports the function.
+const stripHeader = (v: string): string => v.replace(/[\r\n\0]/g, "");
+
+describe("Fuzz: sanitizeHeaderValue invariant", () => {
+  it("never leaves \\r, \\n or \\0 in the output", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 1024 }), (raw) => {
+        const sanitized = stripHeader(raw);
+        expect(sanitized).not.toMatch(/[\r\n\0]/);
+      }),
+      { numRuns: 500 },
+    );
+  });
+
+  it("shrinks every test case with known CRLF to a clean output", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 512 }), fc.string({ maxLength: 512 }), (a, b) => {
+        const raw = `${a}\r\nBcc: attacker@evil.com\r\n${b}`;
+        expect(stripHeader(raw)).not.toMatch(/[\r\n\0]/);
+      }),
+      { numRuns: 200 },
+    );
+  });
+});
+
+describe("Fuzz: createEmailMessage header block is CRLF-safe", () => {
+  // Build a validated-args payload where every user-supplied header
+  // field is fuzzed. The only structural guarantees we give fast-check
+  // are (1) `to` is a non-empty valid-email list (validateEmail rejects
+  // anything else and short-circuits before sanitisation), and (2)
+  // `subject` is a string (the function asserts this implicitly).
+  const validEmail = fc.constantFrom("a@example.com", "b@test.org", "c.d@sub.example.io");
+
+  it("header block never contains a bare injected Bcc/X-/Cc line from a fuzzed subject", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ maxLength: 256 }),
+        fc.array(validEmail, { minLength: 1, maxLength: 3 }),
+        (fuzzedSubject, to) => {
+          const out = createEmailMessage({
+            to,
+            subject: fuzzedSubject,
+            body: "body",
+            mimeType: "text/plain",
+          });
+          // Extract the header block (everything before the first
+          // blank line — RFC 822).
+          const headerBlock = out.split("\r\n\r\n")[0] ?? out;
+          // No raw injected header smuggled in: every header line
+          // must match one of the legitimate ones we build.
+          const allowedPrefixes =
+            /^(From|To|Subject|In-Reply-To|References|Cc|Bcc|MIME-Version|Content-Type|Content-Transfer-Encoding|--):/;
+          for (const line of headerBlock.split("\r\n")) {
+            if (line === "") continue;
+            // Boundary lines start with "--" for multipart, but this
+            // test uses text/plain so none are expected.
+            if (line.startsWith("--")) continue;
+            expect(
+              allowedPrefixes.test(line) || line.startsWith(" ") || line.startsWith("\t"),
+              `unexpected header line after sanitisation: ${JSON.stringify(line)}`,
+            ).toBe(true);
+          }
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});
+
+describe("Fuzz: parseEmailAddresses never throws and returns @-strings", () => {
+  it("always returns a string[] where every entry contains '@' (or the array is empty)", () => {
+    fc.assert(
+      fc.property(fc.string({ maxLength: 512 }), (raw) => {
+        const out = parseEmailAddresses(raw);
+        expect(Array.isArray(out)).toBe(true);
+        for (const email of out) {
+          expect(email).toContain("@");
+        }
+      }),
+      { numRuns: 500 },
+    );
+  });
+
+  it("quoted commas never split", () => {
+    fc.assert(
+      fc.property(
+        fc.string({ minLength: 1, maxLength: 32 }),
+        fc.string({ minLength: 1, maxLength: 32 }),
+        (namePart, domainPart) => {
+          // Build a header like '"<namePart>, <anything>" <user@<domainPart>>'
+          // and verify the parser returns exactly one address.
+          const safeName = namePart.replace(/["\r\n\0]/g, "");
+          const safeDomain = domainPart.replace(/["\r\n\0\s@,]/g, "") || "example.com";
+          const raw = `"${safeName}, extra" <user@${safeDomain}>`;
+          const out = parseEmailAddresses(raw);
+          expect(out.length).toBe(1);
+          expect(out[0]).toContain("@");
+        },
+      ),
+      { numRuns: 200 },
+    );
+  });
+});

--- a/test/fuzz.test.ts
+++ b/test/fuzz.test.ts
@@ -4,11 +4,9 @@
  * for the JS/TS ecosystem.
  *
  * Targets:
- * - `sanitizeHeaderValue` (re-implemented locally, since utl.ts keeps
- *   the function un-exported): the property we care about is that
- *   the output never contains `\r`, `\n`, or `\0` no matter what the
- *   input is. If a future refactor ever exports a new sanitizer, swap
- *   the local copy for the real one here.
+ * - `sanitizeHeaderValue` (imported directly from src/utl.ts — no
+ *   local mirror, so the test exercises the exact production code
+ *   path and cannot drift).
  * - `createEmailMessage`: no user-supplied header value ever survives
  *   as a raw CRLF in the output header block, for any subject /
  *   inReplyTo / references / from / cc / bcc.
@@ -18,20 +16,14 @@
 
 import { describe, it, expect } from "vitest";
 import * as fc from "fast-check";
-import { createEmailMessage } from "../src/utl.js";
+import { createEmailMessage, sanitizeHeaderValue } from "../src/utl.js";
 import { parseEmailAddresses } from "../src/reply-all-helpers.js";
-
-// Mirror the strip pattern used in src/utl.ts#sanitizeHeaderValue so
-// the property is independently testable. A drift here would surface
-// as either a test failure (good) or a too-permissive property (bad) —
-// kept in sync manually; revisit if utl.ts exports the function.
-const stripHeader = (v: string): string => v.replace(/[\r\n\0]/g, "");
 
 describe("Fuzz: sanitizeHeaderValue invariant", () => {
   it("never leaves \\r, \\n or \\0 in the output", () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 1024 }), (raw) => {
-        const sanitized = stripHeader(raw);
+        const sanitized = sanitizeHeaderValue(raw);
         expect(sanitized).not.toMatch(/[\r\n\0]/);
       }),
       { numRuns: 500 },
@@ -42,7 +34,7 @@ describe("Fuzz: sanitizeHeaderValue invariant", () => {
     fc.assert(
       fc.property(fc.string({ maxLength: 512 }), fc.string({ maxLength: 512 }), (a, b) => {
         const raw = `${a}\r\nBcc: attacker@evil.com\r\n${b}`;
-        expect(stripHeader(raw)).not.toMatch(/[\r\n\0]/);
+        expect(sanitizeHeaderValue(raw)).not.toMatch(/[\r\n\0]/);
       }),
       { numRuns: 200 },
     );
@@ -73,14 +65,19 @@ describe("Fuzz: createEmailMessage header block is CRLF-safe", () => {
           // blank line — RFC 822).
           const headerBlock = out.split("\r\n\r\n")[0] ?? out;
           // No raw injected header smuggled in: every header line
-          // must match one of the legitimate ones we build.
+          // must match one of the legitimate ones we build. Since
+          // mimeType = "text/plain" (no multipart), NO boundary-style
+          // line ("--…") should ever appear in the header block — any
+          // such line would be a bona-fide injection and must fail the
+          // test instead of being silently skipped.
           const allowedPrefixes =
-            /^(From|To|Subject|In-Reply-To|References|Cc|Bcc|MIME-Version|Content-Type|Content-Transfer-Encoding|--):/;
+            /^(From|To|Subject|In-Reply-To|References|Cc|Bcc|MIME-Version|Content-Type|Content-Transfer-Encoding):/;
           for (const line of headerBlock.split("\r\n")) {
             if (line === "") continue;
-            // Boundary lines start with "--" for multipart, but this
-            // test uses text/plain so none are expected.
-            if (line.startsWith("--")) continue;
+            expect(
+              line.startsWith("--"),
+              `unexpected boundary-like header line (text/plain path): ${JSON.stringify(line)}`,
+            ).toBe(false);
             expect(
               allowedPrefixes.test(line) || line.startsWith(" ") || line.startsWith("\t"),
               `unexpected header line after sanitisation: ${JSON.stringify(line)}`,


### PR DESCRIPTION
## Summary

Split out of #16 — test suite additions.

- `test: drop unused toolDefinitions import` — CodeQL alert #3 (js/unused-local-variable)
- `test: add fast-check fuzz suite + fix parseEmailAddresses bug` — new `test/fuzz.test.ts` targets sanitizeHeaderValue, createEmailMessage header block, parseEmailAddresses. fast-check caught a real bug where `parseEmailAddresses("< >")` returned `[""]` — fixed to require `@` inside angle brackets.

Unblocks OpenSSF Scorecard Fuzzing check (recognises fast-check).

## Test plan

- [x] `npm test` green, coverage unchanged
- [x] `npm run lint` passes