### PR TITLE
docs(contributing): one-line DCO reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,10 @@ PRs welcome. Please open an issue first for substantial changes (new tool, break
 6. If you add or rename a tool, update the `Tools` section in the README and the entry in `src/tools.ts` (`toolDefinitions` array) — including the correct `scopes` and the `readOnlyHint` / `destructiveHint` / `idempotentHint` annotations
 7. New file-path inputs must be routed through `resolveDownloadSavePath()` or `assertAttachmentPathAllowed()` (no raw `fs.writeFileSync(userPath, …)` — see `src/utl.ts` for the canonical jail helpers)
 
+## Developer Certificate of Origin
+
+Every commit must carry a `Signed-off-by:` trailer to certify compliance with [DCO 1.1](https://developercertificate.org/). The trailer is added automatically by `git commit -s` or our prepare-commit-msg hook.
+
 ## CodeRabbit review policy
 
 Every PR must pass CodeRabbit's assertive review and obtain a formal `APPROVED` review state before merge (see `.coderabbit.yaml`). `@coderabbitai approve` is allowed only via the built-in auto-review flow; do not click "Commit suggestion" on inline diffs — CodeRabbit-authored commits deadlock branch protection on a solo-maintainer repo.


### PR DESCRIPTION
## Summary

Split out of #16 — one-line DCO reference in CONTRIBUTING.md:

```
Every commit carries a `Signed-off-by:` trailer — adding it (automatic with `git commit -s` or our prepare-commit-msg hook) certifies the DCO 1.1.
```

Pairs with the global `prepare-commit-msg` hook that auto-adds the trailer locally.

## Test plan

- [x] CONTRIBUTING.md renders on GitHub