### PR TITLE
chore(release): v0.9.1 (Node 22 migration)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1] - 2026-04-22
+
+Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 Active-LTS exit. Not a feature release — the `dist/index.js` behaviour is unchanged versus 0.9.0.
+
 ### Changed (BREAKING)
 
-- **Node.js floor: `>=22`** (was `>=20.11`). Node 20 reaches end of active LTS on 2026-04-30; keeping the floor there would ship a version on an unmaintained runtime the day after. Active-LTS Node 22 runs maintenance until 2027-04-30, which gives a year of headroom before the next bump. Internally: CI matrix dropped Node 20 (now 22 + 24), the release/verify workflows and the Dockerfile base image pin `node:22-alpine` with an explicit digest, the coverage upload job now runs on Node 22, and `@types/node` was bumped from `^20.19.39` to `^22.19.17` so the TypeScript definitions match the runtime floor. `ROADMAP.md` item **Node.js 22 migration** ticked off; `SECURITY.md` gained a **Supported runtimes** section.
+- **Node.js floor: `>=22`** (was `>=20.11`). Node 20 reaches end of Active LTS on 2026-04-30; keeping the floor there would ship 0.9.0-era packages on an unmaintained runtime the day after. Active-LTS Node 22 runs maintenance until 2027-04-30, which gives a year of headroom before the next cadence bump.
+- **Compile target: `ES2024`** (was `ES2022`). Node 22 implements the full ES2024 surface (`Object.groupBy`, `Map.groupBy`, `Promise.withResolvers`, iterator helpers, etc.) — the TypeScript `target` and `lib` now match, so stdlib additions don't need polyfills.
+- **Bundle target: `tsup target: node22`** (was `node20`). Without this the bundler was still down-levelling Node 22 intrinsics (WebCrypto globals, `AbortSignal.any`) and the shipped `dist/index.js` wasn't actually taking advantage of the higher floor we just set.
+
+### Changed
+
+- `@types/node` bumped from `^20.19.39` to `^22.19.17` so the TypeScript definitions line up with the runtime floor.
+- CI matrix dropped Node 20 — builds now run on Node 22 + 24. The coverage-upload step (Codecov) moved from Node 20 to Node 22.
+- Release and verify-release workflows set up Node 22 (`setup-node node-version: "22"`).
+- Dockerfile base image pinned to `node:22-alpine@sha256:8ea2348b068a9544dae7317b4f3aafcdc032df1647bb7d768a05a5cad1a7683f` (digest resolved via Docker Hub API at release time).
+- `package-lock.json` refreshed via `npm update` — minor bumps within existing carets (`typescript-eslint` 8.58 → 8.59, etc.), no semver-major shifts.
+
+### Added
+
+- `.nvmrc` with `22` so `nvm use` in a fresh checkout matches `engines.node` and the CI matrix without guessing.
+- `SECURITY.md` gained a **Supported runtimes** section stating the Node 22 floor and the LTS window. Existing "Verifying releases (once v1 is out)" section retitled to "Verifying releases" — v0.9.0 being already on npm, the future tense no longer applies.
+- `ROADMAP.md` item **Node.js 22 migration** ticked off; **Optional audit log** also removed (shipped in 0.9.0 as `GMAIL_MCP_AUDIT_LOG`).
+- README comparison-table tweaks: Node-floor cells marked ❌/❌/✅ for readability, published-on-npm cells deduplicated (package names were already in the GitHub-repo row), statement coverage refreshed to `>45%` (was `>42%`), `tsup` ESM-bundle cell now notes the `node22` + `ES2024` target.
+- Issue-template `bug_report.yml` / `dependabot.yml` / `CONTINUITY.md` / `ASSURANCE_CASE.md` scrubbed of stray Node 20 / `20.11` references.
 
 ## [0.9.0] - 2026-04-22
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klodr/gmail-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -414,7 +414,7 @@ async function main() {
   const server = new Server(
     {
       name: "gmail",
-      version: "0.9.0",
+      version: "0.9.1",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary

Bumps @klodr/gmail-mcp from 0.9.0 to 0.9.1. Single focus: shipping everything that landed via #33 and #34 so the Node 22 migration is actually on npm ahead of Node 20 leaving Active LTS on 2026-04-30.

No runtime/behaviour change vs 0.9.0 — dist/index.js is functionally identical, just recompiled against Node 22 / ES2024 targets.

## What is (now) on npm

- `engines.node >=22`
- `tsup target: node22`
- `tsconfig target: ES2024` (+ matching `lib`)
- `@types/node ^22.19.17`
- `.nvmrc` with `22`
- CI / release / verify-release workflows all on Node 22
- Dockerfile pinned to `node:22-alpine@sha256:8ea2348b068a…`
- README / SECURITY / ROADMAP / CHANGELOG / CONTINUITY / ASSURANCE_CASE / issue templates / dependabot all scrubbed of stray Node 20 refs

## Test plan

- [x] `npm test` — 264/264 on Node 24 locally
- [ ] CI green on this PR (Node 22 + 24)
- [ ] Tag `v0.9.1` pushed after merge triggers `release.yml` — Sigstore + SLSA + SPDX + CycloneDX all signed
- [ ] `npm view @klodr/gmail-mcp@0.9.1 dist.attestations` returns SLSA v1 provenance
- [ ] `npm audit signatures` clean on install