### PR TITLE
docs(node-lts): correct Node 20/22 LTS terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.9.1] - 2026-04-22
 
-Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 Active-LTS exit. Not a feature release — the `dist/index.js` behaviour is unchanged versus 0.9.0.
+Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 end-of-life. Not a feature release — the `dist/index.js` behaviour is unchanged versus 0.9.0.
 
 ### Changed (BREAKING)
 
-- **Node.js floor: `>=22`** (was `>=20.11`). Node 20 reaches end of Active LTS on 2026-04-30; keeping the floor there would ship 0.9.0-era packages on an unmaintained runtime the day after. Active-LTS Node 22 runs maintenance until 2027-04-30, which gives a year of headroom before the next cadence bump.
+- **Node.js floor: `>=22`** (was `>=20.11`). Node 20 reaches end-of-life on 2026-04-30; keeping the floor there would ship 0.9.0-era packages on an unmaintained runtime the day after. Node 22 is in Maintenance LTS through 2027-04-30, which gives a year of headroom before the next cadence bump.
 - **Compile target: `ES2024`** (was `ES2022`). Node 22 implements the full ES2024 surface (`Object.groupBy`, `Map.groupBy`, `Promise.withResolvers`, iterator helpers, etc.) — the TypeScript `target` and `lib` now match, so stdlib additions don't need polyfills.
 - **Bundle target: `tsup target: node22`** (was `node20`). Without this the bundler was still down-levelling Node 22 intrinsics (WebCrypto globals, `AbortSignal.any`) and the shipped `dist/index.js` wasn't actually taking advantage of the higher floor we just set.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Response target: **acknowledgment within 48 hours**, fix or mitigation plan with
 
 ## Supported runtimes
 
-`@klodr/gmail-mcp` supports **Node.js ≥ 22** (Active LTS, maintained through 2027-04-30). The 0.x series on npm previously shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22+ because Node 20 leaves Active LTS that day and stops receiving security patches shortly after. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`@klodr/gmail-mcp` supports **Node.js ≥ 22** (Maintenance LTS, supported through 2027-04-30). The 0.x series on npm previously shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22+ because Node 20 reaches end-of-life on 2026-04-30. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 


### PR DESCRIPTION
## Summary

Three slips against the official [nodejs/Release schedule](https://github.com/nodejs/Release) landed in v0.9.1 release notes and are still on `main`:

- Node 20 reaches **end-of-life** on 2026-04-30, **not** "end of Active LTS" — Node 20 has been in Maintenance LTS since 2024-10-22.
- Node 22 is in **Maintenance LTS** (since 2025-10-21), not Active LTS.
- `Active-LTS Node 22 runs maintenance` was internally contradictory anyway.

Fixed in `CHANGELOG.md` (the `[0.9.1]` BREAKING note) and `SECURITY.md` (the **Supported runtimes** section).

Same fix as already merged on klodr/mercury-invoicing-mcp#72 — aligning the two repos.

## Note on v0.9.1

The npm-side `@klodr/gmail-mcp@0.9.1` release notes (auto-extracted from the CHANGELOG at tag time) carry the old wording. The tag is immutable so we live with it; this PR sets `main` straight for the next release cut.

## Test plan

- [x] No code change, docs only — no test impact.
- [ ] CI green on this PR (no source files touched).
- [ ] Optional: surface the corrected wording in the next release (`0.9.2` or whichever).