### PR TITLE
fix(scopes): delete_email requires mail.google.com, not gmail.modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`delete_email` / `batch_delete_emails` required scope corrected to `mail.google.com`** (upstream GongRzhe#47). The two tools were gated on `gmail.modify`, but the Google API `users.messages.delete` endpoint specifically rejects `gmail.modify` with HTTP 403 "Insufficient Permission" — only the legacy `mail.google.com` scope authorizes permanent delete (`gmail.modify` stops at moving to Trash). The bug was silently carried from upstream: the tool was advertised to LLMs but every invocation failed at Google. Users who need permanent delete now authenticate with `--scopes=mail.google.com,gmail.settings.basic` (or add `mail.google.com` to their existing scopes). Users who don't need it keep the default `gmail.modify` floor and the two delete tools are correctly filtered out of the registered tool list at startup.
+- **`SCOPE_MAP` gained `mail.google.com`** pointing to the legacy bare URL `https://mail.google.com/` (the only Google scope not served under `https://www.googleapis.com/auth/…`).
+
 ## [0.9.1] - 2026-04-22
 
 Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 Active-LTS exit. Not a feature release — the `dist/index.js` behaviour is unchanged versus 0.9.0.

--- a/README.md
+++ b/README.md
@@ -167,6 +167,11 @@ npx @klodr/gmail-mcp auth --scopes=gmail.readonly,gmail.send
 
 # Everything (default; explicit)
 npx @klodr/gmail-mcp auth --scopes=gmail.modify,gmail.settings.basic
+
+# Default + permanent delete (delete_email / batch_delete_emails)
+# gmail.modify only authorizes Trash; mail.google.com is the only
+# scope that authorizes purging from Trash.
+npx @klodr/gmail-mcp auth --scopes=mail.google.com,gmail.settings.basic
 ```
 
 ## Safeguards

--- a/README.md
+++ b/README.md
@@ -169,9 +169,13 @@ npx @klodr/gmail-mcp auth --scopes=gmail.readonly,gmail.send
 npx @klodr/gmail-mcp auth --scopes=gmail.modify,gmail.settings.basic
 
 # Default + permanent delete (delete_email / batch_delete_emails)
-# gmail.modify only authorizes Trash; mail.google.com is the only
-# scope that authorizes purging from Trash.
-npx @klodr/gmail-mcp auth --scopes=mail.google.com,gmail.settings.basic
+# gmail.modify authorizes trash; mail.google.com is the only scope
+# that authorizes purging from Trash. Both are listed because the
+# tool gate does exact scope-name matching — a token holding only
+# mail.google.com would not enable the gmail.modify-gated tools,
+# even though Google's scope hierarchy would technically accept the
+# same calls.
+npx @klodr/gmail-mcp auth --scopes=gmail.modify,mail.google.com,gmail.settings.basic
 ```
 
 ## Safeguards

--- a/src/scopes.test.ts
+++ b/src/scopes.test.ts
@@ -21,9 +21,17 @@ describe("SCOPE_MAP / SCOPE_REVERSE_MAP invariants", () => {
     expect(Object.keys(SCOPE_REVERSE_MAP).length).toBe(Object.keys(SCOPE_MAP).length);
   });
 
-  it("every URL uses the https googleapis origin", () => {
-    for (const url of Object.values(SCOPE_MAP)) {
-      expect(url.startsWith("https://www.googleapis.com/auth/")).toBe(true);
+  it("every URL uses an https Google scope origin", () => {
+    // The vast majority sit under https://www.googleapis.com/auth/. The
+    // single exception is the legacy mail.google.com scope, which Google
+    // exposes as the bare https://mail.google.com/ URL — it's the only
+    // scope that authorizes permanent delete (users.messages.delete).
+    for (const [name, url] of Object.entries(SCOPE_MAP)) {
+      if (name === "mail.google.com") {
+        expect(url).toBe("https://mail.google.com/");
+      } else {
+        expect(url.startsWith("https://www.googleapis.com/auth/")).toBe(true);
+      }
     }
   });
 
@@ -31,6 +39,12 @@ describe("SCOPE_MAP / SCOPE_REVERSE_MAP invariants", () => {
     for (const scope of DEFAULT_SCOPES) {
       expect(SCOPE_MAP[scope]).toBeDefined();
     }
+  });
+
+  it("mail.google.com resolves to the legacy bare URL (only scope authorizing permanent delete)", () => {
+    expect(SCOPE_MAP["mail.google.com"]).toBe("https://mail.google.com/");
+    expect(scopeNameToUrl("mail.google.com")).toBe("https://mail.google.com/");
+    expect(scopeUrlToName("https://mail.google.com/")).toBe("mail.google.com");
   });
 });
 

--- a/src/scopes.ts
+++ b/src/scopes.ts
@@ -2,14 +2,18 @@
 //
 // Scope hierarchy (for reference):
 //   - gmail.readonly: Read-only access to emails
-//   - gmail.modify: Read AND write access (superset of readonly)
+//   - gmail.modify: Read AND write access except permanent delete
 //   - gmail.compose: Create drafts and send emails
 //   - gmail.send: Send emails only
 //   - gmail.labels: Manage labels only
 //   - gmail.settings.basic: Manage filters and settings
+//   - mail.google.com: Full access including permanent delete
 //
 // Note: gmail.modify includes all capabilities of gmail.readonly,
-// so you don't need both scopes together.
+// so you don't need both scopes together. mail.google.com is the only
+// scope that authorizes users.messages.delete / users.threads.delete
+// (purge from Trash) — gmail.modify alone returns HTTP 403
+// "Insufficient Permission" on those endpoints.
 
 // Map shorthand scope names to full Google API URLs
 export const SCOPE_MAP: Record<string, string> = {
@@ -20,6 +24,7 @@ export const SCOPE_MAP: Record<string, string> = {
   "gmail.labels": "https://www.googleapis.com/auth/gmail.labels",
   "gmail.settings.basic": "https://www.googleapis.com/auth/gmail.settings.basic",
   "gmail.settings.sharing": "https://www.googleapis.com/auth/gmail.settings.sharing",
+  "mail.google.com": "https://mail.google.com/",
 };
 
 // Reverse map for converting full URLs back to shorthand

--- a/src/tools-scopes.test.ts
+++ b/src/tools-scopes.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from "vitest";
+import { toolDefinitions } from "./tools.js";
+
+describe("delete tools require mail.google.com (Google API requirement)", () => {
+  it("delete_email is gated on mail.google.com, not gmail.modify", () => {
+    const t = toolDefinitions.find((d) => d.name === "delete_email");
+    expect(t).toBeDefined();
+    // gmail.modify can move to Trash but cannot purge — Google API
+    // returns HTTP 403 on users.messages.delete with that scope. The
+    // only scope that authorizes permanent delete is mail.google.com.
+    expect(t!.scopes).toEqual(["mail.google.com"]);
+  });
+
+  it("batch_delete_emails has the same requirement", () => {
+    const t = toolDefinitions.find((d) => d.name === "batch_delete_emails");
+    expect(t).toBeDefined();
+    expect(t!.scopes).toEqual(["mail.google.com"]);
+  });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -468,9 +468,13 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "delete_email",
-    description: "Permanently deletes an email",
+    description: "Permanently deletes an email (purges from Trash)",
     schema: DeleteEmailSchema,
-    scopes: ["gmail.modify"],
+    // Permanent delete requires the full mail.google.com scope.
+    // gmail.modify is enough for trashing (modify_email) but the
+    // users.messages.delete endpoint specifically rejects it with
+    // HTTP 403 "Insufficient Permission".
+    scopes: ["mail.google.com"],
     annotations: { title: "Delete Email", destructiveHint: true },
   },
   {
@@ -482,9 +486,10 @@ export const toolDefinitions: ToolDefinition[] = [
   },
   {
     name: "batch_delete_emails",
-    description: "Permanently deletes multiple emails in batches",
+    description: "Permanently deletes multiple emails in batches (purges from Trash)",
     schema: BatchDeleteEmailsSchema,
-    scopes: ["gmail.modify"],
+    // Same scope requirement as delete_email — see comment above.
+    scopes: ["mail.google.com"],
     annotations: { title: "Batch Delete Emails", destructiveHint: true },
   },
 


### PR DESCRIPTION
## Summary

Critical scope fix carried from upstream (GongRzhe/Gmail-MCP-Server#47 still open).

`delete_email` and `batch_delete_emails` were declared with `scopes: ["gmail.modify"]`, so under the default OAuth grant (`gmail.modify` + `gmail.settings.basic`) the tools were registered and advertised to the LLM. But the Gmail API `users.messages.delete` and `users.threads.delete` endpoints reject `gmail.modify` with HTTP 403 **Insufficient Permission** — the only scope that authorizes permanent delete is the legacy `mail.google.com`. Result: every `delete_email` invocation failed 100% of the time at Google.

## Fix

- `src/scopes.ts` — `SCOPE_MAP` gains `mail.google.com` mapped to `https://mail.google.com/` (the only Gmail scope not served under `https://www.googleapis.com/auth/…`).
- `src/tools.ts` — `delete_email` and `batch_delete_emails` now declare `scopes: ["mail.google.com"]`. Their description strings now mention "purges from Trash" to make the irreversibility explicit.
- `src/scopes.test.ts` — invariant updated to treat `mail.google.com` as the known exception, plus a positive assertion covering both directions of the name↔URL map.
- `src/tools-scopes.test.ts` — new regression test: if a future refactor drops the scope back to `gmail.modify`, it fails immediately.
- `README.md` — adds the `--scopes=mail.google.com,…` auth recipe.

## Behavior change

- Users on the default scope floor (`gmail.modify`) will **no longer see** `delete_email` / `batch_delete_emails` in the registered tool list. Previously the tools were there but broken — so the net UX is strictly better (no misleading tool advertising). Users who want permanent delete add `mail.google.com` to their `--scopes` flag.
- Users who already ran `auth` with `gmail.modify` do **not** need to re-auth unless they actually want delete. The CHANGELOG note points them at the new scope.

## Test plan

- [x] Full suite green locally: 267/267 pass on Node 24
- [ ] CI matrix (Node 22 + 24) green on this PR
- [ ] After merge: next release cut carries the fix on npm