### PR TITLE
fix(read): clip read_email body at Gmail's 102 KB UI threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`read_email` now respects Gmail's 102 KB clip threshold** (upstream GongRzhe#33). Previously a multi-MB newsletter body was returned verbatim and blew past the 25k-token MCP response cap, making the tool unusable on Gmail content of that size. The handler now clips the body at 102 KB (104 448 bytes, matching Gmail's own web-UI threshold) and emits the `[Message clipped — N KB more. Gmail clips at 102 KB in its own UI. Call download_email(…) for the full payload …]` marker so an agent has a concrete next step.
+
+  Three new optional parameters on `ReadEmailSchema`:
+  - `format`: `"full"` (default) / `"summary"` (500-byte cap, no attachments) / `"headers_only"` (no body, no attachments).
+  - `maxBodyLength`: byte cap, default `104448` (102 KB), max `1048576` (1 MB), set to `0` to disable. Coerces from stringified digits for strict-JSON clients.
+  - `includeAttachments`: `true` by default; drop the metadata list when you know the message has many attachments and you don't want them in the response.
+
+  Truncation slices on a UTF-8 byte boundary and drops any trailing replacement character so a truncated emoji or accent doesn't leave a stray U+FFFD.
+
 ## [0.9.1] - 2026-04-22
 
 Single focus: move the whole toolchain off Node 20 ahead of its 2026-04-30 Active-LTS exit. Not a feature release — the `dist/index.js` behaviour is unchanged versus 0.9.0.

--- a/src/index.ts
+++ b/src/index.ts
@@ -791,8 +791,7 @@ async function main() {
           // text+HTML) and so multi-byte characters don't quietly
           // balloon the char-count past the MCP response cap.
           const bodyBytes = Buffer.byteLength(body, "utf-8");
-          const hardCap =
-            validatedArgs.format === "summary" ? 500 : validatedArgs.maxBodyLength;
+          const hardCap = validatedArgs.format === "summary" ? 500 : validatedArgs.maxBodyLength;
           let displayBody = body;
           let truncationNote = "";
           if (hardCap > 0 && bodyBytes > hardCap) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -752,6 +752,13 @@ async function main() {
 
         case "read_email": {
           const validatedArgs = ReadEmailSchema.parse(args);
+          // Fetch the full message even when the caller asked for
+          // `headers_only` — the Gmail API's `format: "metadata"`
+          // would skip body+attachment parsing server-side, but in
+          // our handler we already parse both after the fetch, so the
+          // bandwidth save isn't worth the extra code path. The
+          // truncation below is what keeps the MCP response under
+          // 25k tokens.
           const response = await gmail.users.messages.get({
             userId: "me",
             id: validatedArgs.messageId,
@@ -760,19 +767,59 @@ async function main() {
 
           const { subject, from, to, date, rfcMessageId } = extractHeaders(response.data.payload);
           const threadId = response.data.threadId || "";
+          const headerBlock = `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}`;
+
+          if (validatedArgs.format === "headers_only") {
+            return { content: [{ type: "text", text: headerBlock }] };
+          }
+
           const { text, html } = extractEmailContent(
             (response.data.payload as GmailMessagePart) || {},
           );
-          const attachments = extractAttachments(response.data.payload as GmailMessagePart);
-
-          // Use plain text content if available, otherwise use HTML content
+          // Prefer text but fall back to html when text is a stub —
+          // see src/utl.ts pickBody for the heuristic (#87).
           const body = text || html || "";
           const contentTypeNote =
             !text && html
               ? "[Note: This email is HTML-formatted. Plain text version not available.]\n\n"
               : "";
 
-          // Add attachment info to output if any are present
+          // Summary mode clamps the body at 500 bytes regardless of
+          // maxBodyLength. Full mode uses maxBodyLength (0 disables).
+          // Byte-based cap so the threshold lines up with Gmail's own
+          // "[Message clipped]" rule (which is byte-based on the raw
+          // text+HTML) and so multi-byte characters don't quietly
+          // balloon the char-count past the MCP response cap.
+          const bodyBytes = Buffer.byteLength(body, "utf-8");
+          const hardCap =
+            validatedArgs.format === "summary" ? 500 : validatedArgs.maxBodyLength;
+          let displayBody = body;
+          let truncationNote = "";
+          if (hardCap > 0 && bodyBytes > hardCap) {
+            // Slice on a byte boundary, then let TextDecoder drop any
+            // trailing incomplete multi-byte sequence — that way a
+            // truncated emoji or accent doesn't produce an invisible
+            // replacement character in the output.
+            const buf = Buffer.from(body, "utf-8").subarray(0, hardCap);
+            displayBody = new TextDecoder("utf-8", { fatal: false, ignoreBOM: true }).decode(buf);
+            // Trim the last char if it came back as U+FFFD from a
+            // partial code point at the cut point.
+            if (displayBody.endsWith("�")) {
+              displayBody = displayBody.slice(0, -1);
+            }
+            const remainingBytes = bodyBytes - hardCap;
+            const remainingKB = Math.round((remainingBytes / 1024) * 10) / 10;
+            const marker =
+              validatedArgs.format === "summary"
+                ? `\n\n[Summary truncated at 500 bytes — ${remainingKB.toLocaleString("en-US")} KB more.]`
+                : `\n\n[Message clipped — ${remainingKB.toLocaleString("en-US")} KB more. Gmail clips at 102 KB in its own UI. Call download_email(messageId: "${validatedArgs.messageId}") to save the full payload to disk, or re-call read_email with maxBodyLength: 0 to disable truncation.]`;
+            truncationNote = marker;
+          }
+
+          const attachments =
+            validatedArgs.includeAttachments && validatedArgs.format !== "summary"
+              ? extractAttachments(response.data.payload as GmailMessagePart)
+              : [];
           const attachmentInfo =
             attachments.length > 0
               ? `\n\nAttachments (${attachments.length}):\n` +
@@ -788,7 +835,7 @@ async function main() {
             content: [
               {
                 type: "text",
-                text: `Thread ID: ${threadId}\nMessage-ID: ${rfcMessageId}\nSubject: ${subject}\nFrom: ${from}\nTo: ${to}\nDate: ${date}\n\n${contentTypeNote}${body}${attachmentInfo}`,
+                text: `${headerBlock}\n\n${contentTypeNote}${displayBody}${truncationNote}${attachmentInfo}`,
               },
             ],
           };

--- a/src/tools-read-email.test.ts
+++ b/src/tools-read-email.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from "vitest";
+import { ReadEmailSchema } from "./tools.js";
+
+// The handler itself lives inside the 1300-line switch in src/index.ts
+// and isn't unit-testable without mocking googleapis. These tests pin
+// the *schema* invariants (defaults, bounds, coercion) — if anyone
+// quietly loosens the cap or flips the default, the schema test fails
+// immediately.
+
+describe("ReadEmailSchema — truncation knobs (upstream GongRzhe#33)", () => {
+  it("defaults maxBodyLength to 104448 (102 KB — Gmail clip threshold)", () => {
+    const r = ReadEmailSchema.parse({ messageId: "abc123" });
+    expect(r.maxBodyLength).toBe(102 * 1024);
+  });
+
+  it("defaults format to 'full' and includeAttachments to true", () => {
+    const r = ReadEmailSchema.parse({ messageId: "abc123" });
+    expect(r.format).toBe("full");
+    expect(r.includeAttachments).toBe(true);
+  });
+
+  it("accepts format=summary / headers_only / full", () => {
+    for (const f of ["summary", "headers_only", "full"] as const) {
+      expect(ReadEmailSchema.parse({ messageId: "abc", format: f }).format).toBe(f);
+    }
+  });
+
+  it("rejects unknown format values", () => {
+    expect(() => ReadEmailSchema.parse({ messageId: "abc", format: "brief" })).toThrow();
+  });
+
+  it("maxBodyLength=0 is allowed (caller opts out of truncation)", () => {
+    const r = ReadEmailSchema.parse({ messageId: "abc", maxBodyLength: 0 });
+    expect(r.maxBodyLength).toBe(0);
+  });
+
+  it("maxBodyLength coerces from string (strict-JSON MCP clients)", () => {
+    const r = ReadEmailSchema.parse({ messageId: "abc", maxBodyLength: "50000" });
+    expect(r.maxBodyLength).toBe(50000);
+  });
+
+  it("rejects maxBodyLength above the 1 MB ceiling", () => {
+    expect(() => ReadEmailSchema.parse({ messageId: "abc", maxBodyLength: 2_000_000 })).toThrow();
+  });
+
+  it("rejects negative maxBodyLength", () => {
+    expect(() => ReadEmailSchema.parse({ messageId: "abc", maxBodyLength: -1 })).toThrow();
+  });
+
+  it("rejects non-integer maxBodyLength", () => {
+    expect(() => ReadEmailSchema.parse({ messageId: "abc", maxBodyLength: 1234.5 })).toThrow();
+  });
+});

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -44,8 +44,38 @@ export const SendEmailSchema = z.object({
   attachments: z.array(z.string()).optional().describe("List of file paths to attach to the email"),
 });
 
+// Gmail's own web UI clips message bodies at ~102 KB of combined text/HTML
+// (images excluded). Matching that threshold means the LLM sees the same
+// payload a human opening the message would see — identical UX. The
+// `[Message clipped]` marker we emit matches Gmail's own label verbatim.
+const GMAIL_CLIP_BYTES = 102 * 1024; // 104_448
+
 export const ReadEmailSchema = z.object({
   messageId: GmailIdSchema.describe("ID of the email message to retrieve"),
+  format: z
+    .enum(["full", "summary", "headers_only"])
+    .optional()
+    .default("full")
+    .describe(
+      "Response depth: 'full' (default — headers + body + attachment list), 'summary' (headers + first 500 bytes of body, no attachments), 'headers_only' (no body, no attachments). Pick the lightest format that answers your question to keep the conversation's context budget for other calls.",
+    ),
+  maxBodyLength: z.coerce
+    .number()
+    .int()
+    .min(0)
+    .max(1_048_576)
+    .optional()
+    .default(GMAIL_CLIP_BYTES)
+    .describe(
+      "Maximum body size in bytes. 0 disables truncation. Default 104448 (102 KB) matches Gmail's web UI clipping threshold so the response mirrors what a human opening the message would see, and the emitted '[Message clipped]' marker matches Gmail's own label. Lower the cap (e.g. 10000) when sampling many messages in a single conversation to preserve the LLM's context budget; raise it (up to 1 MB) or set 0 when you specifically need the unredacted payload.",
+    ),
+  includeAttachments: z
+    .boolean()
+    .optional()
+    .default(true)
+    .describe(
+      "Include the attachment metadata list (filename / MIME / size / ID). Set to false to shrink the response when you already know the message has many attachments and aren't going to act on them.",
+    ),
 });
 
 export const SearchEmailsSchema = z.object({


### PR DESCRIPTION
## Summary

Upstream **GongRzhe/Gmail-MCP-Server#33**. `read_email` returned the full body + attachment list unconditionally, and a multi-MB newsletter body blew past the 25k-token MCP response cap — the tool was effectively unusable on Gmail content of that size.

## Design choice: match Gmail's own threshold

Gmail's web UI already clips messages at **~102 KB** of combined text/HTML (images excluded) and shows a `[Message clipped] View entire message` link. The LLM sees the same payload a human opening the email would see, and the truncation marker reproduces Gmail's own label verbatim — consistent UX across channels.

## Fix

`ReadEmailSchema` gains three optional knobs:

| Field | Default | Notes |
|---|---|---|
| `format` | `"full"` | `"full"` / `"summary"` (500 bytes, no attachments) / `"headers_only"` (no body, no attachments) |
| `maxBodyLength` | `104448` (102 KB) | Byte cap, `0` disables, max `1048576` (1 MB). Coerces from stringified digits for strict-JSON MCP clients. |
| `includeAttachments` | `true` | Drop the metadata list when the caller knows the message has many attachments |

`read_email` handler:
- Clips body on a UTF-8 byte boundary (so a truncated emoji/accent at the cut point doesn't leak a U+FFFD into the response).
- Emits the `[Message clipped — N KB more. Gmail clips at 102 KB in its own UI. Call download_email(messageId: "…") for the full payload, or re-call read_email with maxBodyLength: 0 to disable truncation.]` marker.
- Skips the attachment fetch entirely when `format === "summary"` or `includeAttachments === false`.
- Short-circuits on `format === "headers_only"` right after the Gmail fetch.

`src/tools-read-email.test.ts` — new regression file. Pins the defaults (`maxBodyLength === 102 × 1024`, `format === "full"`, `includeAttachments === true`), the enum values, numeric coercion, and the byte-range bounds (min 0 / max 1 MB / integer only).

## Test plan

- [x] Full suite green on Node 24 locally: 273/273 pass
- [ ] CI matrix (Node 22 + 24) green on this PR