### PR TITLE
docs: competitors benchmark + v0.10 parity roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | `CONTRIBUTING.md` | ❌ | ❌ | ✅ |
 | `.github/FUNDING.yml` | ❌ | ❌ | ✅ |
 
-The klodr fork is the only one of the three with **(a)** source-path jails that make prompt-injection attachment exfiltration inert, **(b)** a modern supply chain (Scorecard, Socket, Sigstore), and **(c)** an in-repo review policy (`.coderabbit.yaml`) that every PR must pass before merge.
+`klodr/gmail-mcp` is the only one of the three with **(a)** source-path jails that make prompt-injection attachment exfiltration inert, **(b)** a modern supply chain (Scorecard, Socket, Sigstore), and **(c)** an in-repo review policy (`.coderabbit.yaml`) that every PR must pass before merge.
 
 ## Installation
 
@@ -203,7 +203,7 @@ See [ROADMAP.md](./ROADMAP.md).
 
 ## Ecosystem
 
-The wider Gmail-MCP landscape — 29 standalone repositories and 323 forks of the original GongRzhe server — is reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md). That page covers which ideas we borrowed, which we chose not to, and where klodr sits on the maturity axes.
+The wider Gmail-MCP landscape — 29 standalone repositories and 323 forks of the original GongRzhe server — is reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md). That page covers which ideas we borrowed, which we chose not to, and where `klodr/gmail-mcp` sits on the maturity axes.
 
 ## Contributing
 
@@ -223,9 +223,9 @@ MIT — see [LICENSE](./LICENSE).
 
 ## History
 
-This repository is the klodr maintenance fork of a two-step upstream chain:
+`klodr/gmail-mcp` is the maintenance fork of a two-step upstream chain:
 
 - **[GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server)** — the original server. Unmaintained since August 2025 (7+ months with zero maintainer activity and 72+ unmerged pull requests).
 - **[ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server)** — Arty MacKiewicz's active fork, which merged a pile of long-pending community PRs: reply threading ([#91](https://github.com/GongRzhe/Gmail-MCP-Server/pull/91)), reply-all ([#3](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/3) by @MaxGhenis), `list_filters` fix ([#4](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/4) by @nicholas-anthony-ai), `--scopes` flag ([#6](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/6) by @tansanDOTeth), CI/CD hardening ([#9](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/9)) + security hardening ([#10](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/10)) + dependency CVE fixes ([#11](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/11)) by @JF10R, tool annotations ([#14](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/14) by @bryankthompson), `download_email` ([#13](https://github.com/ArtyMcLabin/Gmail-MCP-Server/pull/13) by @icanhasjonas).
 
-This klodr fork carries all of the above forward and adds the supply-chain / path-jail / review-policy layer (see comparison table above). Credit to every PR author along the chain.
+`klodr/gmail-mcp` carries all of the above forward and adds the supply-chain / path-jail / review-policy layer (see comparison table above). Credit to every PR author along the chain.

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ Every write tool is annotated with `destructiveHint` / `readOnlyHint` / `idempot
 
 See [ROADMAP.md](./ROADMAP.md).
 
+## Ecosystem
+
+The wider Gmail-MCP landscape — 29 standalone repositories and 323 forks of the original GongRzhe server — is reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md). That page covers which ideas we borrowed, which we chose not to, and where klodr sits on the maturity axes.
+
 ## Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the test / build / lint checklist and release process.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,26 +1,53 @@
 # Roadmap
 
-Loose planning horizon of ~12 months, ordered by intent (not a commitment):
+Loose planning horizon of ~12 months, ordered by intent (not a commitment).
 
 ## Near-term (next release cycle)
 
 - **Complete code audit** — this fork inherits code from two upstream chains (GongRzhe → ArtyMcLabin) and still carries patterns, dead branches, and duplicated helpers from both. A single pass through every file in `src/`, with the security-hardening posture as the baseline, to remove what is not used, consolidate what is duplicated, and document what remains non-obvious. Not a rewrite — a cleanup. Blocks v1.0.0.
 - **Test coverage on `src/index.ts`** — the single `CallToolRequestSchema` dispatcher + its 25 tool cases + the OAuth callback path are currently 0% covered (the file is untouched by tests; global statement coverage sits at ~39% because everything else is ≥ 93%). Raising this requires either a refactor that pulls each tool-case body into a directly-callable helper (preferred) or a mocked-googleapis integration pass (heavier). Target: global statement coverage ≥ 70% before v1.0.0, ideally ≥ 85%.
 - **Re-tighten Codecov thresholds — deadline 2026-05-15** — `codecov.yml` was temporarily relaxed (`project.target: 35%` / `patch.target: 75%`) when the vitest coverage scope was corrected to include every `src/**/*.ts` (previously v8 silently omitted un-imported files, inflating the apparent global to ~93%). The loosened gate is a bridge. Once the handler-extraction refactor lands and global coverage climbs back to ≥ 80%, bump `project.target` back to `auto` with `threshold: 0.5%`, and `patch.target` back to `95%` with `threshold: 1.5%`. Hard deadline so the relaxed config doesn't drift into permanent tolerance.
-- **v1.0.0 on npm** — cut the first tagged release of `@klodr/gmail-mcp` once the audit lands on `main`; every release is signed with Sigstore (keyless GitHub OIDC), ships an SLSA in-toto attestation, and carries npm provenance.
+- **v1.0.0 on npm** — cut the first tagged release of `@klodr/gmail-mcp` once the audit and the parity + ergonomics items below land on `main`; every release is signed with Sigstore (keyless GitHub OIDC), ships an SLSA in-toto attestation, and carries npm provenance.
 - **Recipient pairing gate** — add a `pair_recipient` tool and a `~/.gmail-mcp/paired.json` allowlist so `send_email` / `reply_all` / `draft_email` refuse to email an address the human has never approved, capping the blast radius of a prompt-injected `send_email` call.
 - **Migrate `Server` (legacy) → `McpServer` (ergonomic SDK API)** — the server is instantiated via the low-level `new Server(..., { capabilities: { tools: {} } })` pattern inherited from the GongRzhe → ArtyMcLabin fork chain. `CallToolRequestSchema` dispatches through a 1300-line switch over 25 tool cases, capabilities are declared by hand, and Zod → JSON Schema conversion is explicit. The modern `McpServer` API (already used by mercury-invoicing-mcp and faxdrop-mcp) replaces all of that with `server.registerTool(name, { description, inputSchema }, handler)` and `server.registerPrompt(...)` — capabilities auto-declared, dispatch/validation handled by the SDK, shorter error surface. The migration folds naturally into the **Complete code audit** item above: extract each tool-case into its own handler module (→ testable directly, unblocks the 70%+ coverage target), then register them against an `McpServer`. Hold until those two items are scheduled together.
 
+## v0.10.0 — Parity release
+
+Bring `klodr/gmail-mcp` up to the hardening baseline already shipped in the sibling MCP servers [mercury-invoicing-mcp](https://github.com/klodr/mercury-invoicing-mcp) and [faxdrop-mcp](https://github.com/klodr/faxdrop-mcp). These items land as a group because they share a prerequisite (middleware extraction) and together constitute the hardening floor the other two repos already enforce.
+
+- **Extract `src/middleware.ts`** — the rate-limit and audit-log wiring currently lives inline inside the `CallToolRequestSchema` switch in `src/index.ts`. Extract a `wrapToolHandler(name, handler)` middleware, mirroring `mercury-invoicing-mcp/src/middleware.ts:359` and `faxdrop-mcp/src/middleware.ts:203`. This is the prerequisite that unlocks dry-run, structuredContent, timeouts, and sanitizeForLlm without duplicating glue code in 25 switch cases.
+- **`GMAIL_MCP_DRY_RUN` environment flag** — when set, every write tool (`send_email`, `reply_all`, `draft_email`, `delete_email`, `batch_modify_emails`, `batch_delete_emails`, `modify_email`, `create_label`, `update_label`, `delete_label`, `create_filter`, `delete_filter`) short-circuits before calling Gmail and returns the payload it would have sent, with sensitive fields redacted. Matches `MERCURY_MCP_DRY_RUN` (mercury middleware.ts:255) and `FAXDROP_MCP_DRY_RUN` (faxdrop middleware.ts:25). Useful for CI smoke tests, agent debugging, and human-in-the-loop approval flows.
+- **`sanitizeForLlm` fence** — wrap all attacker-influenced fields returned to the LLM (message body, subject, snippet, sender display name, thread participant names, attachment filenames) in `<untrusted-tool-output>…</untrusted-tool-output>` fences after stripping C0 control characters. Same helper already shipped at `faxdrop-mcp/src/sanitize.ts` and `mercury-invoicing-mcp/src/sanitize.ts`. Gmail is the highest-exposure surface in the three: any email can carry a prompt-injection payload in its subject or body and today we relay it unfenced.
+- **`AbortSignal.timeout` on every Gmail API call** — wrap every `gmail.users.*` call with a 30-second timeout (matching mercury `client.ts:72`). Without it, a slow Gmail response hangs the entire MCP stdio session and there is no way for the client to recover without killing the process.
+- **`structuredContent` in `ToolResult`** — the MCP 2025-06-18 specification requires `structuredContent` for programmatic consumers. Current gmail-mcp emits zero `structuredContent` fields; faxdrop emits it in 13 places; mercury emits it throughout. Add it alongside the existing text content block so MCP clients that introspect the structured payload (registries, test harnesses) see the shape of each response.
+- **Audit log elision-by-length** — keep the existing blocklist strategy on credentials (`token`, `password`, `authorization`) but add per-field length elision on free-form string payloads (`body`, `subject`, `snippet`) so the JSONL audit trail carries a `[…245 chars]` marker rather than the full attacker-controlled text. Hybrid of mercury's blocklist and faxdrop's `redactForAudit` elision pattern (faxdrop middleware.ts:96+), adapted to gmail's wider field surface.
+- **`scripts/prod-readonly-test.mjs`** — a pre-release smoke-test that runs a gmail.readonly token against `list_email_labels`, `search_emails q:in:inbox`, and a handful of message reads, and fails the release if anything crashes. Matches the `prod-readonly-test.mjs` that already ships in `mercury-invoicing-mcp/scripts/`. The parallel `sandbox-test.mjs` from mercury does not apply here — Gmail, like FaxDrop, has no vendor-provided sandbox environment.
+- **`SECURITY.md` expansion** — pull in the sections present in mercury's and faxdrop's SECURITY.md that are absent from ours: SBOM disclosure line, response-time targets for vulnerability reports, explicit scope boundaries, and "Security best practices when using this MCP" covering token scoping, host-side filesystem containment, and audit-log consumption.
+
 ## Gmail API surface not yet wrapped
 
-The MCP currently covers ~25 tools across messages, threads, labels, and filters. Planned additions as demand emerges:
+The MCP currently covers ~25 tools across messages, threads, labels, and filters. Planned additions as demand emerges; much of this catches up with the broader surface exposed by [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp) (see [COMPETITORS.md](./docs/COMPETITORS.md)).
 
 - **Drafts CRUD** — `drafts.list`, `drafts.get`, `drafts.update`, `drafts.delete`, `drafts.send` (only `drafts.create` is wired today via `draft_email`).
 - **Send-as aliases** — `settings.sendAs.*` (create / update / delete / verify) for managing Gmail aliases programmatically.
 - **Vacation responder** — `settings.vacation` get/update for enabling/disabling the auto-responder.
 - **Forwarding addresses** — `settings.forwardingAddresses.*`.
 - **POP / IMAP settings** — `settings.pop`, `settings.imap`.
-- **Push notifications** — `users.watch` + `users.history.list` for near-real-time inbox event streaming.
+- **Delegates** — `settings.delegates.*` (list, add, remove, verify) for shared-mailbox delegation.
+- **S/MIME configuration** — `settings.sendAs.smimeInfo.*` for agents that need to sign or encrypt outbound email.
+- **Language preference** — `settings.language` get/update.
+- **Push notifications** — `users.watch` + `users.stop` + `users.history.list` for near-real-time inbox event streaming via Cloud Pub/Sub, so an agent can react to new mail without polling.
+
+## Ergonomic tool wrappers
+
+Dedicated wrappers that save the agent from reconstructing MIME headers, fetching thread context, or multi-step lookups. Inspired by tools seen in [ustikya/mcp-gmail](https://github.com/ustikya/mcp-gmail) and [fernandezdiegoh/gmail-mcp](https://github.com/fernandezdiegoh/gmail-mcp) (see [COMPETITORS.md](./docs/COMPETITORS.md)).
+
+- **`reply_to_email`** — first-class single-recipient reply. `reply_all` exists today but forcing the agent to choose `reply_all` with manually-trimmed recipients is error-prone; a dedicated `reply_to_email` that replies to the message's `From` address only (or an explicit recipient) fills the common case cleanly and threads `In-Reply-To` / `References` automatically.
+- **`forward_email`** — single-call forward that preserves the original subject with a `Fwd:` prefix, includes a quoted body, carries the attachments forward, and lets the agent add a cover note in one parameter. Today the agent has to fetch the message, assemble a new MIME, and re-upload attachments.
+
+## Transport
+
+- **HTTP / SSE transport alongside stdio** — track the MCP spec's move toward streamable-HTTP. When the SDK makes the HTTP transport first-class, add it as an opt-in mode (`--transport http --port …`) so the server can be self-hosted and reached by remote MCP clients. A `docker-compose.yml` example will land with this item, not before (a compose file only makes sense once there is a long-running daemon to compose).
 
 ## Discoverability
 
@@ -30,4 +57,3 @@ The MCP currently covers ~25 tools across messages, threads, labels, and filters
 
 - **Second maintainer → OpenSSF Gold** — actively welcome co-maintainership via `.github/CODEOWNERS` once a contributor has several merged PRs. Gold requires ≥2 active maintainers; that's the gating constraint.
 - **MCP SDK majors** — follow the `@modelcontextprotocol/sdk` major-version train; migrate to Zod v4-only idioms once the SDK floor allows.
-

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,0 +1,138 @@
+# Competitors & ecosystem snapshot
+
+_Snapshot: 2026-04-23_
+
+## Why this page exists
+
+Before adding a tool, we look at what the community has already built. This page is the record of that exercise: who else ships a Gmail MCP server, what they do well, what we borrow, and what we chose not to borrow.
+
+We maintain it honestly. If a repo here has evolved or we got something wrong, open an issue or a PR.
+
+## Method
+
+- GitHub search for `gmail mcp` across public repositories
+- [Glama.ai MCP connector directory](https://glama.ai/mcp/connectors?query=gmail)
+- All forks of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (the original, and still the most-starred Gmail MCP server at 1098★)
+- For each repo: language, stars, forks, last push, license, tool count, tests, CI, release discipline, unique features
+
+Scope: 29 standalone Gmail-MCP repositories + 323 forks of the GongRzhe upstream.
+
+## Fork lineage of klodr/gmail-mcp
+
+The comparison table in the [README](../README.md#why-this-mcp) already covers the direct lineage:
+
+- [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) — 1098★, original server, dormant since August 2025 (7+ months, 72+ unmerged PRs).
+- [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) — 118★, active TypeScript port, merged long-pending community fixes.
+- **[klodr/gmail-mcp](https://github.com/klodr/gmail-mcp)** — this repo. Adds the supply-chain / path-jail / review-policy layer.
+
+The rest of this page covers the wider landscape.
+
+## Standalone repositories
+
+Sorted by stars, snapshot `2026-04-23`.
+
+### Serious contenders
+
+| Repo | Stars | Forks | Last push | Language | License | What they do well |
+|---|---:|---:|---|---|---|---|
+| [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp) | 51 | 48 | 2025-11-25 | JavaScript | MIT | The widest Gmail API coverage in the landscape — vacation responder, delegates, S/MIME, IMAP/POP, forwarding, language, `users.watch` push notifications, full settings CRUD. ~50 tools. Changesets-based version flow. |
+| [Quantum-369/Gmail-mcp-server](https://github.com/Quantum-369/Gmail-mcp-server) | 17 | 6 | 2025-07-08 | Python | Apache-2.0 | Multi-account keystore: one Gmail MCP instance handling several mailboxes with per-request `account_id` selector. |
+| [Sallytion/Gmail-MCP](https://github.com/Sallytion/Gmail-MCP) | 12 | 7 | 2025-09-17 | TypeScript | — | Separate upstream root (not a fork of GongRzhe). Source of [GodotH/Easy-Gmail-MCP](https://github.com/GodotH/Easy-Gmail-MCP). IMAP/SMTP app-password auth rather than OAuth — simpler install, narrower security model. |
+| [muammar-yacoob/GMail-Manager-MCP](https://github.com/muammar-yacoob/GMail-Manager-MCP) | 9 | 5 | 2025-09-12 | TypeScript | MIT | Release discipline (33 releases on npm), inbox analytics tools, AI-drafted reply suggestions, dedicated batch-label wrappers. |
+
+### Notable POCs and experiments
+
+| Repo | Stars | Language | Notable idea |
+|---|---:|---|---|
+| [vinayak-mehta/gmail-mcp](https://github.com/vinayak-mehta/gmail-mcp) | 6 | Python | Clean minimal read-only POC (3 tools). |
+| [bastienchabal/gmail-mcp](https://github.com/bastienchabal/gmail-mcp) | 0 (6 forks) | Python | Ambitious feature surface: thread-aware `draft_reply` with full sender history, named-entity recognition on message bodies, calendar integration. Infra is thin. |
+| [ustikya/mcp-gmail](https://github.com/ustikya/mcp-gmail) | 2 | TypeScript | First-class `reply_to_email` and `forward_email` tools (instead of reconstructing threading from `send_email`). |
+| [cablate/mcp-google-gmail](https://github.com/cablate/mcp-google-gmail) | 1 | TypeScript | Published on npm; minimal tool surface. |
+| [murphy360/mcp_gmail](https://github.com/murphy360/mcp_gmail) | 0 | Python | Server-side aggregation: `daily_summary`, `category_summary`, `inbox_stats` tools built for agent briefings. Home Assistant integration. |
+| [meyannis/mcpgmail](https://github.com/meyannis/mcpgmail) | 0 | Python | Server-side filter enforcement via `filters.yaml` — tools are capped at the config level rather than by OAuth scope, a privacy-first angle. |
+| [dhagash2310/gmail-mcp](https://github.com/dhagash2310/gmail-mcp) | 0 | Python | 23 tools including a `summarize_recent_emails` digest tool. SSE transport option alongside stdio. |
+| [GodotH/Easy-Gmail-MCP](https://github.com/GodotH/Easy-Gmail-MCP) | 1 | TypeScript | Fork of Sallytion with tightened docs and Docker packaging. |
+
+### The long tail
+
+15 repositories with 0 or 1 stars, typically single-commit prototypes, framework demos, or class assignments. None compete on infrastructure; a few are interesting snapshots of what a given platform thought a "Gmail MCP" should look like.
+
+<details>
+<summary>Long-tail list (click to expand)</summary>
+
+| Repo | Stars | Last push | Language | Note |
+|---|---:|---|---|---|
+| [HitmanLy007/gmail-mcp](https://github.com/HitmanLy007/gmail-mcp) | 1 | 2025-05-16 | JavaScript | Stale fork of shinzo-labs, no divergence visible. |
+| [windsornguyen/gmail-mcp](https://github.com/windsornguyen/gmail-mcp) | 1 | 2026-01-28 | Python | Dedalus framework demo. |
+| [CaptainCrouton89/maps-mcp](https://github.com/CaptainCrouton89/maps-mcp) | 1 | 2025-08-20 | TypeScript | Boilerplate covering several Google services; Gmail is one module of five. |
+| [annyzhou/gmail-mcp](https://github.com/annyzhou/gmail-mcp) | 1 | 2026-01-21 | Python | Dedalus framework demo. |
+| [faithk7/gmail-mcp](https://github.com/faithk7/gmail-mcp) | 0 (1 fork) | 2025-09-14 | JavaScript | Quiet fork of shinzo-labs, no published release. |
+| [0x8687/mcp-gmail-v1](https://github.com/0x8687/mcp-gmail-v1) | 0 (1 fork) | 2025-07-17 | TypeScript | Wraps Composio SaaS rather than calling the Gmail API directly. |
+| [XiangWanggithub/Gmail-mcp](https://github.com/XiangWanggithub/Gmail-mcp) | 0 | 2026-02-18 | Python | — |
+| [victormasson21/foundation-project-mcp](https://github.com/victormasson21/foundation-project-mcp) | 0 | 2025-12-07 | TypeScript | Personal agent with Notion style guide. |
+| [SolonaBot/gmail-mcp](https://github.com/SolonaBot/gmail-mcp) | 0 | 2026-02-09 | TypeScript | Single-commit start, drafts/reply marked "coming soon". |
+| [RichardFelix999/Google-Service-MCP](https://github.com/RichardFelix999/Google-Service-MCP) | 0 | 2025-10-02 | TypeScript | Unattributed copy of `CaptainCrouton89/maps-mcp`. |
+| [PranavMishra28/gmail-mcp](https://github.com/PranavMishra28/gmail-mcp) | 0 | 2025-10-12 | JavaScript | Mono-tool demo (`send_email` via app password). |
+| [nk900600/gmail-mcp](https://github.com/nk900600/gmail-mcp) | 0 | 2025-07-24 | JavaScript | Shinzo-labs derivative. |
+| [martingaston/mcp-gmail](https://github.com/martingaston/mcp-gmail) | 0 | 2026-01-09 | Python | Experimental, 3 tools. |
+| [fred-drake/gmail-mcp](https://github.com/fred-drake/gmail-mcp) | 0 | 2026-01-07 | Python | FastMCP scaffold, 5 tools. |
+| [fernandezdiegoh/gmail-mcp](https://github.com/fernandezdiegoh/gmail-mcp) | 0 | 2026-03-25 | Python | Minimalist, multi-account via environment variables. |
+| [dedalus-labs/gmail-mcp](https://github.com/dedalus-labs/gmail-mcp) | 0 | 2026-02-28 | Python | Dedalus framework demo. |
+
+</details>
+
+## GongRzhe forks
+
+323 forks in total, the vast majority dormant. Beyond **ArtyMcLabin** (which is our own intermediate), only three forks have any meaningful code divergence from upstream:
+
+| Fork | Stars | Commits ahead | What they changed |
+|---|---:|---:|---|
+| [oO/Gmail-MCP-Server](https://github.com/oO/Gmail-MCP-Server) | 1 | 1 | Refactor to a "Gateway + Skills" pattern — collapses the 24 atomic tools into 3 polymorphic ones (`google_mail`, `google_settings`, `google_calendar`) with an `action` parameter. Reduces the `ListTools` catalog size by ~87%. |
+| [alexknowshtml/Gmail-MCP-Server](https://github.com/alexknowshtml/Gmail-MCP-Server) | 1 | 4 | Fixes a `list_filters` bug: the Gmail API returns `response.data.filter` (singular), not `.filters`. This fix is already carried in klodr via the ArtyMcLabin chain. |
+| [Abdullah-MotiWala/Gmail-MCP-Server](https://github.com/Abdullah-MotiWala/Gmail-MCP-Server) | 1 | 2 | Personal adaptation for TypingMind — narrow-purpose. |
+
+310+ forks show `ahead_by=0`: default clones never modified. Nothing to harvest there.
+
+## Ideas we borrowed
+
+All of these end up tracked in [ROADMAP.md](../ROADMAP.md) with attribution to their source.
+
+- **Gmail Settings API completeness** — vacation responder, forwarding, IMAP/POP settings, delegates, S/MIME, language. Inspired by [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp).
+- **`users.watch` / `users.stop` push notifications** — lets an agent wait on Gmail Pub/Sub events instead of polling. Inspired by [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp).
+- **First-class `reply_to_email` / `forward_email` tools** — rather than asking the agent to reconstruct `In-Reply-To` and `References` headers via `send_email`. Inspired by [ustikya/mcp-gmail](https://github.com/ustikya/mcp-gmail) and [fernandezdiegoh/gmail-mcp](https://github.com/fernandezdiegoh/gmail-mcp).
+
+## Ideas we looked at and chose not to adopt
+
+Not value judgments — scope decisions.
+
+- **"Gateway + Skills" tool collapse** ([oO/Gmail-MCP-Server](https://github.com/oO/Gmail-MCP-Server)). Smaller `ListTools` payload, but it violates MCP's self-describing tools principle: the LLM loses semantic autocomplete on sub-actions and has to be told which `action: ...` strings exist via external documentation. Modern LLMs handle 25–30 tools without degradation, so the catalog size isn't our bottleneck.
+- **Multi-account keystore with per-request selection** ([Quantum-369/Gmail-mcp-server](https://github.com/Quantum-369/Gmail-mcp-server), [fernandezdiegoh/gmail-mcp](https://github.com/fernandezdiegoh/gmail-mcp)). A single-tenant OAuth store keeps the blast radius of a prompt injection narrow. Users who need several accounts can run the server twice with different config paths.
+- **Server-side digest tools** (`summarize_inbox`, `daily_summary`, `category_summary` — [murphy360/mcp_gmail](https://github.com/murphy360/mcp_gmail), [dhagash2310/gmail-mcp](https://github.com/dhagash2310/gmail-mcp)). LLMs already summarize raw headers well. An opinionated server-side digest couples us to a specific use-case and shifts logic away from the place it's easiest to iterate on.
+- **Filter enforcement via `filters.yaml`** ([meyannis/mcpgmail](https://github.com/meyannis/mcpgmail)). Overlaps with our OAuth-scope filter (the tool list is already filtered at startup based on granted scopes) and our recipient pairing gate (planned in ROADMAP). Revisit if a concrete policy use-case emerges that neither of those addresses.
+- **HTTP / SSE transport alongside stdio** ([dhagash2310/gmail-mcp](https://github.com/dhagash2310/gmail-mcp)). The MCP spec is converging on streamable-HTTP; we'll revisit when the SDK makes it idiomatic.
+- **Inbox analytics tools** (`inbox_stats`, top-senders distribution — [muammar-yacoob/GMail-Manager-MCP](https://github.com/muammar-yacoob/GMail-Manager-MCP)). Same reasoning as digest tools: the LLM composes this from `search_emails` when it actually needs it.
+- **Dedicated batch-label wrappers** (`batch_apply_labels`, `batch_remove_labels` — [muammar-yacoob/GMail-Manager-MCP](https://github.com/muammar-yacoob/GMail-Manager-MCP)). Covered by the generic `batch_modify_emails`. Syntactic sugar with no semantic gain.
+
+## Where klodr/gmail-mcp sits
+
+- **Not the largest catalog** — shinzo-labs covers more Gmail Settings endpoints; we're closing that gap (see ROADMAP).
+- **Not the most stars** — GongRzhe has 1098. We're young (v0.9.x, tagged April 2026).
+- **The only implementation in the landscape** combining:
+  - CodeQL Advanced + Socket Security + OpenSSF Scorecard + Snyk on every PR
+  - Sigstore keyless signing + SLSA in-toto attestations + SPDX/CycloneDX SBOMs on every release
+  - npm provenance statements
+  - 273 vitest tests + fast-check property-based fuzz suite + hardening-specific test file
+  - Path-jail defenses (`GMAIL_MCP_ATTACHMENT_DIR`, `GMAIL_MCP_DOWNLOAD_DIR` with `O_NOFOLLOW` + post-`mkdir` realpath re-verification)
+  - OAuth scope filtering at startup — tool list is filtered before the LLM ever sees it
+  - Cryptographic MIME boundaries, CRLF sanitization on both email-assembly paths
+  - `.coderabbit.yaml` assertive-profile gate that every PR must pass
+
+The bet: agent-platform operators care more about what an MCP can't be coerced into doing than about how many Gmail endpoints it wraps. Coverage gaps close in a release cycle; a hardening backbone takes longer to build.
+
+## Help keep this page honest
+
+- Missing a repository? Open a PR against `docs/COMPETITORS.md`.
+- Disagree with a verdict or think we mischaracterised your project? Open an issue — we'll fix it or reply in-thread.
+- If your work is cited here and you'd like the attribution adjusted (or the link to your repo swapped for a personal page), ping [@klodr](https://github.com/klodr) directly.
+
+This snapshot reflects the state of the ecosystem on `2026-04-23`. Stars, last-push dates, and forks move; the tradeoffs usually don't.

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -88,7 +88,7 @@ Sorted by stars, snapshot `2026-04-23`.
 | Fork | Stars | Commits ahead | What they changed |
 |---|---:|---:|---|
 | [oO/Gmail-MCP-Server](https://github.com/oO/Gmail-MCP-Server) | 1 | 1 | Refactor to a "Gateway + Skills" pattern — collapses the 24 atomic tools into 3 polymorphic ones (`google_mail`, `google_settings`, `google_calendar`) with an `action` parameter. Reduces the `ListTools` catalog size by ~87%. |
-| [alexknowshtml/Gmail-MCP-Server](https://github.com/alexknowshtml/Gmail-MCP-Server) | 1 | 4 | Fixes a `list_filters` bug: the Gmail API returns `response.data.filter` (singular), not `.filters`. This fix is already carried in klodr via the ArtyMcLabin chain. |
+| [alexknowshtml/Gmail-MCP-Server](https://github.com/alexknowshtml/Gmail-MCP-Server) | 1 | 4 | Fixes a `list_filters` bug: the Gmail API returns `response.data.filter` (singular), not `.filters`. This fix is already carried in `klodr/gmail-mcp` via the ArtyMcLabin chain. |
 | [Abdullah-MotiWala/Gmail-MCP-Server](https://github.com/Abdullah-MotiWala/Gmail-MCP-Server) | 1 | 2 | Personal adaptation for TypingMind — narrow-purpose. |
 
 310+ forks show `ahead_by=0`: default clones never modified. Nothing to harvest there.


### PR DESCRIPTION
## Summary

Adds `docs/COMPETITORS.md` — a snapshot of the wider Gmail-MCP landscape (29 standalone repos + 323 forks of GongRzhe/Gmail-MCP-Server). Serious contenders, notable POCs, long-tail appendix, and a list of ideas we borrowed vs. chose not to adopt, each with attribution.

Reworks `ROADMAP.md` around a parity audit against the sibling MCPs (mercury-invoicing-mcp, faxdrop-mcp) and the features we found in the competitor review:

- New **v0.10.0 Parity release** section: middleware extraction, `GMAIL_MCP_DRY_RUN`, `sanitizeForLlm` fence, `AbortSignal.timeout`, `structuredContent`, audit-log elision, `prod-readonly-test.mjs`, SECURITY.md expansion.
- **Gmail API surface** section extended with delegates, S/MIME, language settings.
- New **Ergonomic tool wrappers** section for `reply_to_email` + `forward_email`.
- New **Transport** section defers HTTP/SSE until the SDK makes it idiomatic.

Links the new page from README.md under an `Ecosystem` heading.

## Context

- Snapshot date: 2026-04-23.
- The parity audit identified `sanitizeForLlm` as the highest-impact gap: gmail-mcp relays attacker-influenced fields (subject, body, snippet, sender display name) to the LLM without any fence, while mercury and faxdrop already ship the wrapper for much less exposed fields.
- The competitor review surfaced shinzo-labs/gmail-mcp as the main Gmail API surface competitor and pointed to first-class reply/forward tool wrappers as worthwhile ergonomic additions.

## Test plan

- [x] `npx prettier --check docs/COMPETITORS.md ROADMAP.md README.md`
- [ ] CodeRabbit pass
- [ ] Qodo reviewers (DeepSeek + Gemini) pass
- [ ] CI (lint, build, CodeQL, Socket, Snyk) pass