### PR TITLE
chore(node): tighten engines floor to >=22.11

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     # Keep @types/node pinned on the 22.x line so its type surface
-    # tracks engines.node (>=22). A semver-major bump would declare
+    # tracks engines.node (>=22.11). A semver-major bump would declare
     # APIs the runtime doesn't guarantee. Reopen only when we move the
     # engines floor to a newer LTS.
     ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Node.js floor tightened to `>=22.11`** (was `>=22`). `22.11.0` is the LTS-tagged entry point for the Node 22 "Jod" line (October 2024); the previous `>=22` would have accepted the pre-LTS `22.0`–`22.10` releases which predate the LTS designation. Aligned with the sibling repos `klodr/faxdrop-mcp` and `klodr/mercury-invoicing-mcp`, all moving to the same floor.
 - `.github/dependabot.yml` `@types/node` major-version-clamp comment aligned to the new `>=22.11` floor.
+- `llms-install.md` prerequisite updated to **Node.js ≥ 22.11**.
+- `SECURITY.md` "Supported runtimes" section updated to state `Node.js ≥ 22.11` with the LTS-tag rationale.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Node.js floor tightened to `>=22.11`** (was `>=22`). `22.11.0` is the LTS-tagged entry point for the Node 22 "Jod" line (October 2024); the previous `>=22` would have accepted the pre-LTS `22.0`–`22.10` releases which predate the LTS designation. Aligned with the sibling repos `klodr/faxdrop-mcp` and `klodr/mercury-invoicing-mcp`, all moving to the same floor.
+- `.github/dependabot.yml` `@types/node` major-version-clamp comment aligned to the new `>=22.11` floor.
+
 ### Added
 
 - **`read_email` now respects Gmail's 102 KB clip threshold** (upstream GongRzhe#33). Previously a multi-MB newsletter body was returned verbatim and blew past the 25k-token MCP response cap, making the tool unusable on Gmail content of that size. The handler now clips the body at 102 KB (104 448 bytes, matching Gmail's own web-UI threshold) and emits the `[Message clipped — N KB more. Gmail clips at 102 KB in its own UI. Call download_email(…) for the full payload …]` marker so an agent has a concrete next step.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Response target: **acknowledgment within 48 hours**, fix or mitigation plan with
 
 ## Supported runtimes
 
-`@klodr/gmail-mcp` supports **Node.js ≥ 22** (Maintenance LTS, supported through 2027-04-30). The 0.x series on npm previously shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22+ because Node 20 reaches end-of-life on 2026-04-30. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`@klodr/gmail-mcp` supports **Node.js ≥ 22.11** (the LTS-tagged entry point of the Node 22 "Jod" line, October 2024; in Maintenance LTS through 2027-04-30). The 0.x series on npm previously shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22.11+ because Node 20 reaches end-of-life on 2026-04-30 and the `>=22.11` floor skips the pre-LTS 22.0–22.10 releases that predate the LTS designation. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -7,7 +7,7 @@ client that can launch a stdio child process can use this server.
 
 ## Prerequisites the assistant should verify
 
-1. **Node.js ≥ 22** is installed (`node --version`).
+1. **Node.js ≥ 22.11** is installed (`node --version`).
 2. **npx** is on `PATH` (ships with Node).
 3. The user has — or is willing to create — a Google Cloud project with the
    Gmail API enabled and an OAuth client credential file

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=22.11"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22"
+    "node": ">=22.11"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary

Tighten the `engines.node` floor from `>=22` to `>=22.11` to pin on the LTS-tagged entry point of the Node 22 "Jod" line (October 2024). The previous `>=22` floor accepted `22.0`–`22.10` — pre-LTS releases that predate the LTS designation.

## Why

The v0.9.1 Node 22 migration used `>=22` for simplicity. Revisited today while aligning the sibling MCPs — `klodr/faxdrop-mcp` historically used tight-specific-minor floors (`>=20.11` previously) and applying that style to the 22 line means `>=22.11`. Doing the same across the three klodr/* MCPs for consistency.

## Changes

- `package.json` engines: `>=22.11` (was `>=22`).
- `.github/dependabot.yml` `@types/node` major-clamp comment aligned.

## Test plan

- [x] `npm install` refreshes the lockfile cleanly.
- [x] `npx prettier --check .`.
- [ ] CI (lint, build matrix 22 + 24, CodeQL, Socket, Snyk).
- [ ] CodeRabbit + Qodo dual reviewers.

## Companion PRs

- klodr/faxdrop-mcp#63 — same tightening bundled into its Node 22 migration.
- klodr/mercury-invoicing-mcp — PR opening next.