### PR TITLE
chore(parity): .npmrc engine-strict=true

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`.npmrc` with `engine-strict=true`** — aligns with sibling repos `klodr/faxdrop-mcp` and `klodr/mercury-invoicing-mcp`. The manifest's `engines.node: >=22.11` is enforced as a hard `npm install` failure rather than a soft warning, so someone trying to install under Node 20 sees a blocking error instead of the package installing silently and crashing at runtime on an ES2024 intrinsic. No effect on consumers who already run Node 22+.
 - **`read_email` now respects Gmail's 102 KB clip threshold** (upstream GongRzhe#33). Previously a multi-MB newsletter body was returned verbatim and blew past the 25k-token MCP response cap, making the tool unusable on Gmail content of that size. The handler now clips the body at 102 KB (104 448 bytes, matching Gmail's own web-UI threshold) and emits the `[Message clipped — N KB more. Gmail clips at 102 KB in its own UI. Call download_email(…) for the full payload …]` marker so an agent has a concrete next step.
 
   Three new optional parameters on `ReadEmailSchema`:


### PR DESCRIPTION
## Summary

Drops `.npmrc` with `engine-strict=true` so the `engines.node: >=22.11` floor in `package.json` is enforced as a **hard `npm install` failure** instead of a soft warning. Mirrors what the sibling repos `klodr/faxdrop-mcp` (`.npmrc` since v0.3.7) and `klodr/mercury-invoicing-mcp` (since v0.9.2) already ship.

Without this, a user on Node 20 sees a warning line scroll past, the install completes anyway, and the first `import` of an ES2024 intrinsic (`Object.groupBy`, iterator helpers, etc.) crashes at runtime with a less legible stack. With it, the install refuses immediately with a clear error pointing at the Node version constraint.

## Test plan

- [x] `npm test` — 319 passing
- [x] `npx prettier --check .` — clean
- [x] No functional change; the only runtime impact is at `npm install` time on out-of-range Node versions.
- [ ] CI green on the PR

## Out of scope

- **Codecov Test Analytics wiring** is deliberately *not* included — adding an analytics layer on a test suite that covers ~39 % of the package (`src/index.ts` alone is 0 % — see `ROADMAP.md` "Near-term" item) would give us flaky-test dashboards on an under-tested surface. Revisit after the `src/index.ts` handler-extraction refactor lifts global coverage toward the ROADMAP-targeted 70 %+.
