### PR TITLE
chore(release): 0.9.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.2] - 2026-04-23
 
 ### Changed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klodr/gmail-mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "0.9.1",
+      "version": "0.9.2",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -422,7 +422,7 @@ async function main() {
   const server = new Server(
     {
       name: "gmail",
-      version: "0.9.1",
+      version: "0.9.2",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary

Cuts release **v0.9.2** — wraps the upstream-drain work from GongRzhe (6 fixes landed) + the parity alignments with sibling repos `klodr/faxdrop-mcp` and `klodr/mercury-invoicing-mcp`.

### Fixed (upstream drain)

- `delete_email` / `batch_delete_emails` scope corrected to `mail.google.com` (GongRzhe#47) — #38
- Outgoing `From:` header carries display name (GongRzhe#77) — #42
- Tool arguments tolerate JSON-stringified values from strict-JSON MCP clients (GongRzhe#95/#96) — #40
- `read_email` falls back to HTML when text part is a placeholder stub (Qodo #41) — #41
- `read_email` respects Gmail's 102 KB clip threshold (GongRzhe#33) — #43
- LTS terminology fix (Node 20 EOL, Node 22 Maintenance LTS) — #37

### Added

- `.npmrc` with `engine-strict=true` (parity with sibling repos) — #46
- `read_email` clip threshold + `format` / `maxBodyLength` / `includeAttachments` parameters — #43

### Changed

- Node.js floor tightened to `>=22.11` (from `>=22`) — #45
- Aligned docs (`llms-install.md`, `SECURITY.md`, `dependabot.yml`)

Version bumped via `npm version 0.9.2 --no-git-tag-version` → `package.json`/`package-lock.json`/`server.json`/`src/index.ts` sync'd by the repo's `scripts/sync-version.mjs` hook. CHANGELOG section rename `Unreleased` → `[0.9.2] - 2026-04-23`.

## Test plan

- [x] `npm test` — 335 passing
- [x] `npx prettier --check .` — clean
- [ ] CI green on the PR
- [ ] After merge: tag `v0.9.2` on `main` → `.github/workflows/release.yml` publishes to npm, generates signed SBOMs, and creates the GitHub Release.
