### PR TITLE
chore(deps): bump Node floor to >=22.22 (22.22.2 CVEs)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,7 +7,7 @@ updates:
       day: "monday"
     open-pull-requests-limit: 5
     # Keep @types/node pinned on the 22.x line so its type surface
-    # tracks engines.node (>=22.11). A semver-major bump would declare
+    # tracks engines.node (>=22.22). A semver-major bump would declare
     # APIs the runtime doesn't guarantee. Reopen only when we move the
     # engines floor to a newer LTS.
     ignore:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Node.js floor bumped to `>=22.22`** (was `>=22.11`). Node 22.22.2 ships security fixes for seven CVEs, including two high-severity ones (TLS/SNI callback handling and HTTP header validation). The 22.22.x line is the current in-maintenance LTS patch train; pinning the floor there gives users a known-patched runtime instead of the pre-CVE 22.11 baseline. Aligned with the sibling repos `klodr/faxdrop-mcp`, `klodr/mercury-invoicing-mcp`, and the private `klodr/relayfi-mcp`, all moving to `>=22.22` in the same pass. Also updates `SECURITY.md` "Supported runtimes", `llms-install.md` prerequisite, and `.github/dependabot.yml` `@types/node` major-clamp comment to the new floor.
+
 ### Fixed
 
 - **60-second hard timeout on every Gmail API call** — `google.options({ timeout: 60_000 })` is now applied before the `gmail` client is constructed, so every `gmail.users.*` call inherits the cap via gaxios. Without this, a slow Gmail response would hang the MCP stdio session with no way for the client to recover short of killing the process (v0.10.0 parity item — mercury has a 30 s cap at `src/client.ts:72`, faxdrop relies on upstream response headers). **60 s rather than 30 s** because gmail has two slow-path surfaces mercury lacks: a 25 MB attachment upload on `send_email` (base64-encoded + single POST) routinely pushes past 30 s on a mid-tier mobile uplink, and non-US clients add 200–500 ms per round-trip compounded across gaxios's internal redirects. The ceiling is tunable further via the `GMAIL_MCP_TIMEOUT_MS` env var for mailboxes where a single `messages.list` with a heavy `q:` legitimately runs long.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ Response target: **acknowledgment within 48 hours**, fix or mitigation plan with
 
 ## Supported runtimes
 
-`@klodr/gmail-mcp` supports **Node.js ≥ 22.11** (the LTS-tagged entry point of the Node 22 "Jod" line, October 2024; in Maintenance LTS through 2027-04-30). The 0.x series on npm previously shipped with a `>=20.11` floor; releases cut from 2026-04-30 onward require Node 22.11+ because Node 20 reaches end-of-life on 2026-04-30 and the `>=22.11` floor skips the pre-LTS 22.0–22.10 releases that predate the LTS designation. Older pinned versions of the package remain installable but will not receive back-ported security fixes.
+`@klodr/gmail-mcp` supports **Node.js ≥ 22.22** (the current Maintenance LTS patch train for the Node 22 "Jod" line, in maintenance through 2027-04-30). The 0.x series on npm previously shipped with `>=20.11`, then `>=22.11`; releases cut from 2026-04-23 onward require Node ≥ 22.22 so users pick up the seven CVEs addressed in the 22.22.x security release (two high-severity: TLS/SNI callback handling and HTTP header validation; three medium, two low). Older pinned versions of the package remain installable but will not receive back-ported security fixes.
 
 ## Verifying releases
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -7,7 +7,7 @@ client that can launch a stdio child process can use this server.
 
 ## Prerequisites the assistant should verify
 
-1. **Node.js ≥ 22.11** is installed (`node --version`).
+1. **Node.js ≥ 22.22** is installed (`node --version`).
 2. **npx** is on `PATH` (ships with Node).
 3. The user has — or is willing to create — a Google Cloud project with the
    Gmail API enabled and an OAuth client credential file

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">=22.11"
+    "node": ">=22.22"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",


### PR DESCRIPTION
## Summary
- Bump `engines.node` from `>=22.11` to `>=22.22` across the klodr/* MCP family so users pick up the seven CVEs addressed in Node 22.22.2 (two high-severity: TLS/SNI callback + HTTP header validation).
- Aligns sibling repos `klodr/gmail-mcp`, `klodr/faxdrop-mcp`, `klodr/mercury-invoicing-mcp`, and the private `klodr/relayfi-mcp` on the same floor.
- Updates the prose that references the old floor: `SECURITY.md`, `llms-install.md`, `.github/dependabot.yml` (`@types/node` major-clamp comment), and (mercury only) `README.md` comparison-table row.

## Test plan
- [ ] `engines.node` change visible in `package.json`
- [ ] CI matrix (Node 22 + 24) still green — `22` resolves to 22.22+ at action runtime
- [ ] No runtime API change (no ES2025 APIs introduced)

Refs: https://github.com/nodejs/node/releases/tag/v22.22.2