### PR TITLE
fix(audit): elide PII fields from audit log by default (M03)

### DIFF
--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -43,13 +43,16 @@ describe("audit-log redactSensitive", () => {
     expect(items[1]?.credentials).toBe("[REDACTED]");
   });
 
-  it("elides body/htmlBody strings with length marker", () => {
+  it("elides body/htmlBody/subject/to PII fields with length marker", () => {
     const body =
       "This is a 100-character email body padding padding padding padding padding padding padding padding";
     const input = { to: ["a@b.com"], subject: "hi", body, htmlBody: "<p>x</p>" };
     const out = redactSensitive(input) as Record<string, unknown>;
-    expect(out.to).toEqual(["a@b.com"]);
-    expect(out.subject).toBe("hi");
+    // PII fields (to/subject) are also elided by default to keep audit
+    // logs free of counterparty data. See ELIDED_KEYS + the
+    // GMAIL_MCP_AUDIT_LOG_VERBOSE escape hatch.
+    expect(out.to).toBe("[ELIDED:1 items]");
+    expect(out.subject).toMatch(/^\[ELIDED:\d+ chars\]$/);
     expect(out.body).toMatch(/^\[ELIDED:\d+ chars\]$/);
     expect(out.htmlBody).toMatch(/^\[ELIDED:\d+ chars\]$/);
   });
@@ -60,8 +63,8 @@ describe("audit-log redactSensitive", () => {
     expect(out.attachments).toBe("[ELIDED:2 items]");
   });
 
-  it("leaves non-sensitive fields intact", () => {
-    const input = { to: ["x@y.com"], subject: "ok", threadId: "abc123" };
+  it("leaves non-sensitive, non-PII fields intact", () => {
+    const input = { threadId: "abc123", maxResults: 5, format: "full" };
     const out = redactSensitive(input) as Record<string, unknown>;
     expect(out).toEqual(input);
   });
@@ -130,7 +133,7 @@ describe("audit-log logAudit", () => {
     expect(entry.tool).toBe("send_email");
     expect(entry.result).toBe("ok");
     expect((entry.args as Record<string, unknown>).access_token).toBe("[REDACTED]");
-    expect((entry.args as Record<string, unknown>).to).toEqual(["a@b.com"]);
+    expect((entry.args as Record<string, unknown>).to).toBe("[ELIDED:1 items]");
     expect(typeof entry.ts).toBe("string");
   });
 

--- a/src/audit-log.test.ts
+++ b/src/audit-log.test.ts
@@ -79,6 +79,29 @@ describe("audit-log redactSensitive", () => {
   it("SENSITIVE_KEYS is frozen", () => {
     expect(Object.isFrozen(SENSITIVE_KEYS)).toBe(true);
   });
+
+  it("keeps PII fields readable when GMAIL_MCP_AUDIT_LOG_VERBOSE=true", async () => {
+    // The verbose escape hatch is evaluated at module load, so re-import
+    // the module with the env var flipped on to exercise the branch.
+    const prev = process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE;
+    process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE = "true";
+    try {
+      const { vi } = await import("vitest");
+      vi.resetModules();
+      const { redactSensitive: redactVerbose } = await import("./audit-log.js");
+      const input = { to: ["a@b.com"], subject: "hi", body: "body", attachments: ["f"] };
+      const out = redactVerbose(input) as Record<string, unknown>;
+      // Size-only elision still applies (body + attachments elided)…
+      expect(out.body).toMatch(/^\[ELIDED:\d+ chars\]$/);
+      expect(out.attachments).toBe("[ELIDED:1 items]");
+      // …but PII fields (to, subject) are now passed through verbatim.
+      expect(out.to).toEqual(["a@b.com"]);
+      expect(out.subject).toBe("hi");
+    } finally {
+      if (prev === undefined) delete process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE;
+      else process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE = prev;
+    }
+  });
 });
 
 describe("audit-log logAudit", () => {

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -50,11 +50,40 @@ const SENSITIVE_KEYS_SET: ReadonlySet<string> = new Set(SENSITIVE_KEYS);
 
 /**
  * Keys whose *value* is elided rather than redacted, because they
- * typically carry large free-form content that would bloat the audit
- * log without adding operational value. Elided to "[ELIDED:N chars]"
- * so reviewers can still see that the field was present and its size.
+ * typically carry large free-form content OR attacker-controlled
+ * content that would bloat the audit log without adding operational
+ * value — AND can carry PII or prompt-injection payloads if left raw.
+ * Elided to "[ELIDED:N chars]" so reviewers can still see that the
+ * field was present and its size.
+ *
+ * The "size-only" set: `body`, `htmlbody`, `data`, `attachments` —
+ * bulky by nature, never needed at call-review time.
+ *
+ * The "PII + attacker-control" set: `subject`, `to`, `cc`, `bcc`,
+ * `from`, `snippet`, `q` (the `search_emails` query), `forward` (the
+ * filter action that writes an email address, i.e. a potential
+ * exfiltration channel if the log itself leaks). Those reconstruct
+ * the full conversation from the log and expose counterparty data
+ * that a security-audit log has no business keeping. To re-enable
+ * full-fidelity inspection, set `GMAIL_MCP_AUDIT_LOG_VERBOSE=true`
+ * which restricts elision to the size-only set.
  */
-const ELIDED_KEYS: ReadonlySet<string> = new Set(["body", "htmlbody", "data", "attachments"]);
+const SIZE_ELIDED_KEYS = ["body", "htmlbody", "data", "attachments"] as const;
+const PII_ELIDED_KEYS = [
+  "subject",
+  "to",
+  "cc",
+  "bcc",
+  "from",
+  "snippet",
+  "q",
+  "forward",
+] as const;
+
+const ELIDED_KEYS: ReadonlySet<string> =
+  process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE === "true"
+    ? new Set<string>(SIZE_ELIDED_KEYS)
+    : new Set<string>([...SIZE_ELIDED_KEYS, ...PII_ELIDED_KEYS]);
 
 /**
  * Recursively walk a value, redacting sensitive keys and eliding

--- a/src/audit-log.ts
+++ b/src/audit-log.ts
@@ -69,16 +69,7 @@ const SENSITIVE_KEYS_SET: ReadonlySet<string> = new Set(SENSITIVE_KEYS);
  * which restricts elision to the size-only set.
  */
 const SIZE_ELIDED_KEYS = ["body", "htmlbody", "data", "attachments"] as const;
-const PII_ELIDED_KEYS = [
-  "subject",
-  "to",
-  "cc",
-  "bcc",
-  "from",
-  "snippet",
-  "q",
-  "forward",
-] as const;
+const PII_ELIDED_KEYS = ["subject", "to", "cc", "bcc", "from", "snippet", "q", "forward"] as const;
 
 const ELIDED_KEYS: ReadonlySet<string> =
   process.env.GMAIL_MCP_AUDIT_LOG_VERBOSE === "true"

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -191,10 +191,15 @@ describe("wrapToolHandler", () => {
       expect(result.structuredContent).toMatchObject({
         dryRun: true,
         tool: "send_email",
-        // body is in the audit-log ELIDED_KEYS list (attacker-controlled
-        // free-form field) so it is elided here the same way the audit
-        // log records it — sanitized view, same everywhere.
-        wouldCallWith: { to: "a@b.c", subject: "hi", body: "[ELIDED:5 chars]" },
+        // body / subject / to are all in the audit-log ELIDED_KEYS list
+        // (attacker-controlled or PII free-form fields) so they are
+        // elided here the same way the audit log records them —
+        // sanitized view, same everywhere.
+        wouldCallWith: {
+          to: "[ELIDED:5 chars]",
+          subject: "[ELIDED:2 chars]",
+          body: "[ELIDED:5 chars]",
+        },
       });
       // The dry-run payload's text content is fenced by sanitizeForLlm
       // before emit (happy-path goes through the sanitize wrapper), so
@@ -217,7 +222,7 @@ describe("wrapToolHandler", () => {
       const payload = result.structuredContent as {
         wouldCallWith: Record<string, unknown>;
       };
-      expect(payload.wouldCallWith.to).toBe("a@b.c");
+      expect(payload.wouldCallWith.to).toBe("[ELIDED:5 chars]");
       expect(payload.wouldCallWith.access_token).toBe("[REDACTED]");
       expect(payload.wouldCallWith.authorization).toBe("[REDACTED]");
     });


### PR DESCRIPTION
## Summary
Security audit finding: `ELIDED_KEYS` previously only covered the bulky-payload set (body/htmlBody/data/attachments). PII fields (subject/to/cc/bcc/from/snippet/q/forward) were written to the audit log verbatim — reconstituting the full conversation into a security-audit log is counterproductive.

New default: elide both sets. `GMAIL_MCP_AUDIT_LOG_VERBOSE=true` restricts elision to size-only for operators who need full-fidelity audit.

## Test plan
- 376/376 tests green
- Tests updated to reflect PII elision is now the default