### PR TITLE
docs(utl): align sanitizeAttachmentFilename doc with actual behaviour

### DIFF
--- a/src/utl.ts
+++ b/src/utl.ts
@@ -268,14 +268,31 @@ export function sanitizeHeaderValue(value: string): string {
  * as-is, all of which are hostile once the filename is passed to
  * `path.resolve` or the filesystem.
  *
- * The policy: replace every character in the intersection of (POSIX
- * path separators) + (NUL / C0 / DEL / C1 control chars) + (Windows
- * reserved chars) with `_`. Collapse repeated separators and strip
- * leading dots so a crafted `..\..\etc\passwd` becomes `__.__.etc_passwd`,
- * never an ancestor traversal. Fallback to `"attachment"` if the
- * normalised result is empty or consists only of dots.
+ * Policy (matches the `ATTACHMENT_HOSTILE_CHARS` regex below):
+ * - Replace each hostile character (POSIX separator `/`, Windows
+ *   separator `\`, NUL / C0 / DEL / C1 control chars, Windows reserved
+ *   `: * ? " < > |`) with `_`. The substitution is 1:1 — repeated
+ *   hostile chars are NOT collapsed, so `//` becomes `__` (two
+ *   underscores), not a single `_`.
+ * - Strip only leading dots (`^\.+`). Dots in the middle of the name
+ *   are preserved, so `foo.bar.pdf` stays as-is.
+ * - Fallback to `"attachment"` when the normalised result is either
+ *   empty OR consists entirely of `_` characters — the latter covers
+ *   inputs that were nothing but hostile chars (e.g. `////` → `____`).
  *
- * Idempotent. Returns ASCII-safe output.
+ * Worked example: `..\..\etc\passwd` → replace-hostile →
+ * `.._.._etc_passwd` → strip-leading-dots → `_.._etc_passwd`. Repeated
+ * separators are NOT collapsed; the only removal is the leading `..`.
+ *
+ * This helper shapes the leaf filename only — it is NOT the
+ * anti-path-traversal gate. The gate is downstream in `src/index.ts`:
+ * `path.resolve(savePath, filename)` followed by a
+ * `startsWith(savePath + path.sep)` containment check, plus the
+ * `safeWriteFile` open-with-O_NOFOLLOW/O_EXCL pattern.
+ *
+ * Idempotent. Unicode characters outside the hostile set (accents,
+ * emojis, CJK) pass through untouched — intentional so a user
+ * downloading `résumé.pdf` sees `résumé.pdf` on disk, not `r_sum_.pdf`.
  */
 const ATTACHMENT_HOSTILE_CHARS = new RegExp(
   "[" + "\\u0000-\\u001F" + "\\u007F-\\u009F" + '/\\\\:*?"<>|' + "]",


### PR DESCRIPTION
## Summary

Follow-up to #59 (just merged) addressing a CodeRabbit finding that arrived after the merge. The doc comment above `sanitizeAttachmentFilename` in `src/utl.ts` claimed four things the code does not actually do.

### What was wrong in the doc

| Doc said | Code actually does |
|---|---|
| "Collapse repeated separators" | 1:1 replacement — `//` → `__` (two underscores), no collapse |
| Worked example `..\..\etc\passwd → __.__.etc_passwd` | Real output is `_.._etc_passwd` (replace-hostile then strip-leading-dots, no collapse) |
| Fallback "if the normalised result is empty or consists only of dots" | Test is `/^_+$/` — only `_` characters (dots-only inputs are handled by the leading-dot strip before the test) |
| "Returns ASCII-safe output" | Unicode outside the hostile set passes through unchanged — `résumé.pdf` intentionally stays readable |

### What the new doc says

1. Hostile chars are **replaced** with `_` (1:1, not collapsed)
2. Only **leading** dots are stripped (middle dots preserved)
3. Fallback on empty **OR** all-`_` result
4. Unicode pass-through is intentional
5. Explicit note that **this helper is NOT the anti-path-traversal gate** — the gate is `path.resolve + startsWith(savePath + path.sep)` in `src/index.ts` plus `safeWriteFile` O_NOFOLLOW/O_EXCL.

### Why a separate PR

#59 merged before this CR finding could be addressed inline. Rather than reopen / revert, a focused docs-only PR lands the fix with zero behaviour change.

## Test plan

- [x] `npm run lint` clean
- [x] `npx prettier --check src/utl.ts` clean
- [x] `npm test` — all tests still green (34 passing across `utl.test.ts` + `utl-attachment-sanitize.test.ts`)
- [x] `npm run build` clean

## Non-goals

- **Not** changing `sanitizeAttachmentFilename` behaviour — only the doc comment.
- **Not** the anti-path-traversal gate — that lives in `src/index.ts` and `src/utl.ts#safeWriteFile`, and the new doc makes that boundary explicit.