### PR TITLE
refactor(headers): extract makeHeaderGetter (3 dupes → 1 helper)

### DIFF
--- a/src/email-export.ts
+++ b/src/email-export.ts
@@ -4,6 +4,7 @@
 
 import emailAddresses from "email-addresses";
 import type { gmail_v1 } from "googleapis";
+import { makeHeaderGetter } from "./gmail-headers.js";
 
 // Types
 export interface ParsedAddress {
@@ -80,9 +81,7 @@ export function gmailMessageToJson(
   emailContent: { text: string; html: string },
   attachments: EmailAttachment[],
 ): EmailJson {
-  const headers: gmail_v1.Schema$MessagePartHeader[] = message.payload?.headers || [];
-  const getHeader = (name: string) =>
-    headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+  const getHeader = makeHeaderGetter(message.payload?.headers);
 
   const dateStr = getHeader("date");
   let isoDate: string;
@@ -124,9 +123,7 @@ export function emailToTxt(
   emailContent: { text: string; html: string },
   attachments: EmailAttachment[],
 ): string {
-  const headers: gmail_v1.Schema$MessagePartHeader[] = message.payload?.headers || [];
-  const getHeader = (name: string) =>
-    headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+  const getHeader = makeHeaderGetter(message.payload?.headers);
 
   const from = getHeader("from");
   const to = getHeader("to");

--- a/src/gmail-headers.ts
+++ b/src/gmail-headers.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared helpers for reading Gmail API message headers.
+ *
+ * `gmail.users.messages.get` returns headers as an unordered array of
+ * `{ name, value }` records with case-variable names ("From" vs "from",
+ * "Message-ID" vs "Message-Id"). Three sites in the codebase used to
+ * inline the same "find by case-insensitive name, coalesce missing
+ * to empty string" pattern:
+ *
+ *   - `src/email-export.ts` inside `gmailMessageToJson`
+ *   - `src/email-export.ts` inside `emailToTxt`
+ *   - `src/index.ts` inside `extractHeaders`
+ *
+ * Consolidating into one factory avoids the three copies drifting
+ * (e.g. one site adding a null guard the others missed) and gives a
+ * single place to add future header-specific logic (MIME-encoded
+ * values, multi-occurrence folding) when the need arises.
+ */
+
+import type { gmail_v1 } from "googleapis";
+
+/**
+ * Build a function that returns the value of a header by name,
+ * case-insensitively, or an empty string if the header is absent.
+ *
+ * `headers` is accepted as `undefined` so call sites can pass
+ * `message.payload?.headers` directly without a local `|| []` fallback
+ * — the returned getter short-circuits on missing input.
+ *
+ * Usage:
+ *   const getHeader = makeHeaderGetter(message.payload?.headers);
+ *   const subject = getHeader("subject");
+ *   const from    = getHeader("from");
+ */
+export function makeHeaderGetter(
+  headers: gmail_v1.Schema$MessagePartHeader[] | undefined,
+): (name: string) => string {
+  return (name) => headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import {
   ModifyThreadSchema,
 } from "./tools.js";
 import { gmailMessageToJson, emailToTxt, emailToHtml, EmailAttachment } from "./email-export.js";
+import { makeHeaderGetter } from "./gmail-headers.js";
 import { logAudit } from "./audit-log.js";
 import { listPrompts, getPrompt } from "./prompts.js";
 import { wrapToolHandler } from "./middleware.js";
@@ -163,9 +164,7 @@ function extractHeaders(payload: GmailMessagePart | undefined): {
   date: string;
   rfcMessageId: string;
 } {
-  const headers = payload?.headers || [];
-  const getHeader = (name: string) =>
-    headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+  const getHeader = makeHeaderGetter(payload?.headers);
   return {
     subject: getHeader("subject"),
     from: getHeader("from"),


### PR DESCRIPTION
## Summary

HIGH finding from the Explore audit — the case-insensitive header lookup was copy-pasted at **three sites**:

- `src/email-export.ts:84` (inside `gmailMessageToJson`)
- `src/email-export.ts:128` (inside `emailToTxt`)
- `src/index.ts:167` (inside `extractHeaders`)

All three bodies were byte-identical:

```typescript
const headers = ...?.headers || [];
const getHeader = (name) =>
  headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
```

Extracted to `src/gmail-headers.ts#makeHeaderGetter`, a factory that accepts `headers | undefined` so call sites pass `message.payload?.headers` directly (no local `|| []` fallback needed). Single place to evolve if the lookup ever needs MIME-encoded values or multi-occurrence folding.

## Diff at call sites

```diff
- const headers: gmail_v1.Schema$MessagePartHeader[] = message.payload?.headers || [];
- const getHeader = (name: string) =>
-   headers.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+ const getHeader = makeHeaderGetter(message.payload?.headers);
```

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npm test` — 388 tests pass (no new tests needed, observable contract unchanged)
- [x] `npx prettier --check` clean
- [ ] CodeRabbit review clean