### PR TITLE
chore(scripts): add prod-readonly-test.mjs smoke-test

### DIFF
--- a/scripts/prod-readonly-test.mjs
+++ b/scripts/prod-readonly-test.mjs
@@ -111,6 +111,17 @@ if (firstMsgId) {
     messageId: firstMsgId,
     format: "headers_only",
   });
+} else {
+  // No messageId means search_emails returned zero rows or a payload we
+  // could not parse — either way we did NOT exercise the read_email path.
+  // Record the miss so errs > 0 and the process exits non-zero instead
+  // of producing a false-green release gate.
+  console.log("❌ read_email SKIPPED — no messageId from search_emails");
+  results.push({
+    tool: "read_email",
+    status: "error",
+    detail: "No messageId returned from search_emails; read_email path not exercised",
+  });
 }
 
 console.log("\n=== THREADS ===");
@@ -123,6 +134,14 @@ console.log(`   → using threadId = ${firstThreadId ?? "(none)"}`);
 
 if (firstThreadId) {
   await run("get_thread", "get_thread", { threadId: firstThreadId });
+} else {
+  // Same rationale as the read_email branch above.
+  console.log("❌ get_thread SKIPPED — no threadId from list_inbox_threads");
+  results.push({
+    tool: "get_thread",
+    status: "error",
+    detail: "No threadId returned from list_inbox_threads; get_thread path not exercised",
+  });
 }
 
 console.log("\n=== INBOX+THREADS COMBINED ===");

--- a/scripts/prod-readonly-test.mjs
+++ b/scripts/prod-readonly-test.mjs
@@ -70,8 +70,13 @@ async function run(label, name, args = {}) {
       return text;
     }
   } catch (err) {
-    console.log(`💥 ${err.message}`);
-    results.push({ tool: label, status: "exception", detail: err.message });
+    // `err` can be anything a thrower decided on — Error, string, plain
+    // object, or even undefined on a bad rejection. Coerce through the
+    // same ladder the project uses in gmail-errors.ts so the log line
+    // and the recorded detail never collapse to "undefined".
+    const detail = err instanceof Error ? err.message : typeof err === "string" ? err : String(err);
+    console.log(`💥 ${detail}`);
+    results.push({ tool: label, status: "exception", detail });
     return null;
   }
 }

--- a/scripts/prod-readonly-test.mjs
+++ b/scripts/prod-readonly-test.mjs
@@ -1,0 +1,129 @@
+// Production read-only smoke-test for gmail-mcp.
+//
+// Spawns `node dist/index.js` as a child stdio process, connects via
+// the MCP SDK's StdioClientTransport, and walks a minimum viable
+// read path: list labels → search inbox → read first message →
+// list inbox threads → get first thread. Fails on any tool that
+// crashes or comes back with `isError`.
+//
+// Env requirements (all optional except credentials, which the
+// server itself reads from ~/.gmail-mcp/ by default):
+//
+//   GMAIL_MCP_OAUTH_KEYS_PATH   - override client_id/client_secret path
+//   GMAIL_MCP_CREDENTIALS_PATH  - override refresh-token path
+//
+// The OAuth token MUST carry at least `gmail.readonly`. The server's
+// scope filter hides write tools when that is all it has, so this
+// script exercises only read tools regardless.
+//
+// Usage:
+//   npm run build && node scripts/prod-readonly-test.mjs
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SERVER_ENTRY = resolve(__dirname, "..", "dist", "index.js");
+
+const transport = new StdioClientTransport({
+  command: "node",
+  args: [SERVER_ENTRY],
+  stderr: "inherit",
+});
+
+const client = new Client({ name: "gmail-mcp-smoke", version: "0.0.0" });
+await client.connect(transport);
+
+const results = [];
+async function run(label, name, args = {}) {
+  process.stdout.write(`▶ ${label.padEnd(50)} `);
+  try {
+    const res = await client.callTool({ name, arguments: args });
+    const text = res.content?.[0]?.text ?? "";
+    if (res.isError) {
+      const tag = text.includes("401")
+        ? "🔒 401"
+        : text.includes("403")
+          ? "🔒 403"
+          : text.includes("404")
+            ? "⚠️  404"
+            : "❌ ERR";
+      console.log(`${tag} — ${text.slice(0, 80)}`);
+      results.push({ tool: label, status: "error", detail: text });
+      return null;
+    }
+    console.log("✅");
+    results.push({ tool: label, status: "ok" });
+    // Tool responses are text-first; many also carry structuredContent.
+    if (res.structuredContent) return res.structuredContent;
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  } catch (err) {
+    console.log(`💥 ${err.message}`);
+    results.push({ tool: label, status: "exception", detail: err.message });
+    return null;
+  }
+}
+
+console.log("\n=== LABELS ===");
+await run("list_email_labels", "list_email_labels");
+
+console.log("\n=== SEARCH ===");
+const search = await run("search_emails (in:inbox, 3)", "search_emails", {
+  query: "in:inbox",
+  maxResults: 3,
+});
+
+// search_emails returns either a raw array or a { messages: [...] } envelope
+// depending on middleware path. Handle both.
+const firstMsg = Array.isArray(search) ? search[0] : (search?.messages?.[0] ?? search?.[0]);
+const firstMsgId = firstMsg?.id ?? firstMsg?.messageId;
+console.log(`   → using messageId = ${firstMsgId ?? "(none)"}`);
+
+if (firstMsgId) {
+  await run("read_email (txt)", "read_email", {
+    messageId: firstMsgId,
+    format: "txt",
+  });
+  await run("read_email (json)", "read_email", {
+    messageId: firstMsgId,
+    format: "json",
+  });
+}
+
+console.log("\n=== THREADS ===");
+const threads = await run("list_inbox_threads (3)", "list_inbox_threads", {
+  maxResults: 3,
+});
+const firstThread = Array.isArray(threads) ? threads[0] : (threads?.threads?.[0] ?? threads?.[0]);
+const firstThreadId = firstThread?.id ?? firstThread?.threadId;
+console.log(`   → using threadId = ${firstThreadId ?? "(none)"}`);
+
+if (firstThreadId) {
+  await run("get_thread", "get_thread", { threadId: firstThreadId });
+}
+
+console.log("\n=== INBOX+THREADS COMBINED ===");
+await run("get_inbox_with_threads (3)", "get_inbox_with_threads", {
+  maxResults: 3,
+});
+
+console.log("\n========== SUMMARY ==========");
+const ok = results.filter((r) => r.status === "ok").length;
+const errs = results.filter((r) => r.status !== "ok").length;
+console.log(`✅ OK:           ${ok}`);
+console.log(`❌ Errors:       ${errs}`);
+if (errs) {
+  console.log("\nFailures:");
+  for (const r of results.filter((x) => x.status !== "ok")) {
+    console.log(`  - ${r.tool}: ${r.detail?.slice(0, 150) ?? ""}`);
+  }
+}
+
+await client.close();
+process.exit(errs > 0 ? 1 : 0);

--- a/scripts/prod-readonly-test.mjs
+++ b/scripts/prod-readonly-test.mjs
@@ -36,11 +36,17 @@ const transport = new StdioClientTransport({
 const client = new Client({ name: "gmail-mcp-smoke", version: "0.0.0" });
 await client.connect(transport);
 
+const CALL_TIMEOUT_MS = 30_000;
+
 const results = [];
 async function run(label, name, args = {}) {
   process.stdout.write(`▶ ${label.padEnd(50)} `);
   try {
-    const res = await client.callTool({ name, arguments: args });
+    const res = await client.callTool(
+      { name, arguments: args },
+      undefined, // resultSchema — let the SDK default apply
+      { signal: AbortSignal.timeout(CALL_TIMEOUT_MS) },
+    );
     const text = res.content?.[0]?.text ?? "";
     if (res.isError) {
       const tag = text.includes("401")
@@ -86,13 +92,19 @@ const firstMsgId = firstMsg?.id ?? firstMsg?.messageId;
 console.log(`   → using messageId = ${firstMsgId ?? "(none)"}`);
 
 if (firstMsgId) {
-  await run("read_email (txt)", "read_email", {
+  // `format` values must match ReadEmailSchema: "full" | "summary" |
+  // "headers_only". "txt" / "json" are not schema values.
+  await run("read_email (full)", "read_email", {
     messageId: firstMsgId,
-    format: "txt",
+    format: "full",
   });
-  await run("read_email (json)", "read_email", {
+  await run("read_email (summary)", "read_email", {
     messageId: firstMsgId,
-    format: "json",
+    format: "summary",
+  });
+  await run("read_email (headers_only)", "read_email", {
+    messageId: firstMsgId,
+    format: "headers_only",
   });
 }
 


### PR DESCRIPTION
## Summary

Closes the remaining partial-parity item from the v0.10.0 block (`ROADMAP.md` → `v0.10.0 — Parity release` → `scripts/prod-readonly-test.mjs`).

Pre-release smoke-test that exercises the read path of the server end-to-end against a real Gmail token (`gmail.readonly` scope is sufficient). Pattern ported from `mercury-invoicing-mcp/scripts/prod-readonly-test.mjs`; the key difference is that gmail-mcp has no `createServer` factory — the script spawns `node dist/index.js` as a child stdio process and connects via the MCP SDK's `StdioClientTransport`.

## Read coverage

- `list_email_labels`
- `search_emails` (`in:inbox`, 3 results)
- `read_email` on the first message, both `txt` and `json` formats
- `list_inbox_threads` (3 results)
- `get_thread` on the first thread
- `get_inbox_with_threads`

Exits non-zero on any tool that crashes or flags `isError: true`, so a CI release step can gate the `npm publish` on it.

## Safety

The server-side scope filter hides every write tool when the token is `gmail.readonly`-only, so this smoke-test cannot accidentally send or delete anything even on a misconfigured token.

## Test plan

- [x] `npm run build` produces `dist/index.js` — script targets that path
- [x] `npx prettier --check` clean
- [x] No new runtime dependencies (scripts/ is not packaged)
- [ ] Manual verification against a `gmail.readonly` token is the follow-up; this PR lands the script only
- [ ] CodeRabbit review clean

## Non-goals

- **Not** wiring the smoke-test into CI yet — that happens with the v1.0.0 release workflow change, when the `gmail.readonly` token is provisioned as a repository secret.