### PR TITLE
feat(send): recipient pairing gate via GMAIL_MCP_RECIPIENT_PAIRING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Recipient pairing gate** — opt-in allowlist that caps the blast radius of a prompt-injection-driven `send_email` / `reply_all` / `draft_email` call. When `GMAIL_MCP_RECIPIENT_PAIRING=true`, every `To` / `Cc` / `Bcc` address must appear in `~/.gmail-mcp/paired.json` (mode `0o600`, override via `GMAIL_MCP_PAIRED_PATH`). Manage the list via the new `pair_recipient` tool (`action: "add" | "remove" | "list"`). Feature is OFF by default; legacy users see no change. Tracked in `ROADMAP.md` → v1.0.0 block.
+
 ### Changed
 
 - **`download_email` parallelises the Gmail metadata + raw-EML fetches** when `format: "eml"` is requested. The prior implementation awaited `format: "full"` first, then awaited `format: "raw"` serially — two sequential round-trips to Gmail for every EML download. `Promise.all` now issues both in parallel, halving the user-visible latency on EML saves. `json` / `txt` / `html` paths are unchanged — they never needed the second fetch.

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,6 +82,7 @@ import {
   GetInboxWithThreadsSchema,
   DownloadEmailSchema,
   ModifyThreadSchema,
+  PairRecipientSchema,
 } from "./tools.js";
 import { gmailMessageToJson, emailToTxt, emailToHtml, EmailAttachment } from "./email-export.js";
 import { makeHeaderGetter } from "./gmail-headers.js";
@@ -91,6 +92,12 @@ import { wrapToolHandler } from "./middleware.js";
 import { sanitizeForLlm } from "./sanitize.js";
 import { asGmailApiError, buildInvalidGrantPayload, isInvalidGrantError } from "./gmail-errors.js";
 import { resolveDefaultSender } from "./sender-resolver.js";
+import {
+  addPairedAddress,
+  readPairedList,
+  removePairedAddress,
+  requirePairedRecipients,
+} from "./recipient-pairing.js";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -604,6 +611,17 @@ async function main() {
       let message: string;
 
       try {
+        // Recipient pairing gate — no-op unless
+        // GMAIL_MCP_RECIPIENT_PAIRING=true. When enabled, every
+        // To/Cc/Bcc address must appear in ~/.gmail-mcp/paired.json
+        // (manage via the `pair_recipient` tool). Caps the blast
+        // radius of a prompt-injection-driven send.
+        requirePairedRecipients([
+          ...(validatedArgs.to ?? []),
+          ...(validatedArgs.cc ?? []),
+          ...(validatedArgs.bcc ?? []),
+        ]);
+
         // Resolve `from` from the user's default send-as alias (with
         // displayName) when the caller didn't specify one. Using the
         // literal "me" works for the envelope but renders a bare
@@ -828,6 +846,61 @@ async function main() {
             const validatedArgs = SendEmailSchema.parse(args);
             const action = name === "send_email" ? "send" : "draft";
             return await handleEmailAction(action, validatedArgs);
+          }
+
+          case "pair_recipient": {
+            const validatedArgs = PairRecipientSchema.parse(args);
+            const { action, email } = validatedArgs;
+            if (action === "list") {
+              const addresses = readPairedList();
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `Paired recipients (${addresses.length}):\n${addresses.length > 0 ? addresses.map((a) => `  - ${a}`).join("\n") : "  (none)"}`,
+                  },
+                ],
+                structuredContent: { addresses, count: addresses.length },
+              };
+            }
+            if (!email || email.trim() === "") {
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: `pair_recipient action "${action}" requires an \`email\` argument.`,
+                  },
+                ],
+                isError: true,
+              };
+            }
+            if (action === "add") {
+              const res = addPairedAddress(email);
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: res.added
+                      ? `Added "${res.address}" to the paired allowlist.`
+                      : `"${res.address}" was already paired; no change.`,
+                  },
+                ],
+                structuredContent: res,
+              };
+            }
+            // action === "remove"
+            const res = removePairedAddress(email);
+            return {
+              content: [
+                {
+                  type: "text",
+                  text: res.removed
+                    ? `Removed "${res.address}" from the paired allowlist.`
+                    : `"${res.address}" was not in the paired allowlist; no change.`,
+                },
+              ],
+              structuredContent: res,
+            };
           }
 
           case "read_email": {

--- a/src/recipient-pairing.test.ts
+++ b/src/recipient-pairing.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
-import { tmpdir } from "node:os";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   ENV_PAIRED_PATH,
@@ -56,6 +56,11 @@ describe("recipient-pairing", () => {
 
     it("returns the override when absolute", () => {
       expect(getPairedPath()).toBe(join(tmpDir, "paired.json"));
+    });
+
+    it("falls back to ~/.gmail-mcp/paired.json when no override is set", () => {
+      delete process.env[ENV_PAIRED_PATH];
+      expect(getPairedPath()).toBe(join(homedir(), ".gmail-mcp", "paired.json"));
     });
   });
 
@@ -189,6 +194,23 @@ describe("recipient-pairing", () => {
       expect(parsed.version).toBe(1);
       expect(parsed.addresses).toEqual(["alice@example.com"]);
       expect(typeof parsed.updatedAt).toBe("string");
+    });
+
+    it("wraps readFileSync failure into an explanatory error (cause preserved)", () => {
+      // existsSync() returns true on a directory, so the happy-path
+      // guard passes and readFileSync then fails with EISDIR. The
+      // wrapper must surface a user-facing message and preserve the
+      // original error via the `cause` field.
+      mkdirSync(getPairedPath());
+      let caught: unknown;
+      try {
+        readPairedList();
+      } catch (err) {
+        caught = err;
+      }
+      expect(caught).toBeInstanceOf(Error);
+      expect((caught as Error).message).toMatch(/Unable to read paired-recipients file/);
+      expect((caught as Error).cause).toBeDefined();
     });
   });
 });

--- a/src/recipient-pairing.test.ts
+++ b/src/recipient-pairing.test.ts
@@ -1,0 +1,194 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ENV_PAIRED_PATH,
+  ENV_RECIPIENT_PAIRING,
+  addPairedAddress,
+  getPairedPath,
+  isAddressPaired,
+  isPairingEnabled,
+  readPairedList,
+  removePairedAddress,
+  requirePairedRecipients,
+} from "./recipient-pairing.js";
+
+describe("recipient-pairing", () => {
+  let tmpDir: string;
+  const prevEnv = process.env[ENV_RECIPIENT_PAIRING];
+  const prevPath = process.env[ENV_PAIRED_PATH];
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "gmail-mcp-pairing-test-"));
+    process.env[ENV_PAIRED_PATH] = join(tmpDir, "paired.json");
+    delete process.env[ENV_RECIPIENT_PAIRING];
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+    if (prevEnv === undefined) delete process.env[ENV_RECIPIENT_PAIRING];
+    else process.env[ENV_RECIPIENT_PAIRING] = prevEnv;
+    if (prevPath === undefined) delete process.env[ENV_PAIRED_PATH];
+    else process.env[ENV_PAIRED_PATH] = prevPath;
+  });
+
+  describe("isPairingEnabled", () => {
+    it("is false by default", () => {
+      expect(isPairingEnabled()).toBe(false);
+    });
+
+    it('is true only for the exact string "true"', () => {
+      process.env[ENV_RECIPIENT_PAIRING] = "true";
+      expect(isPairingEnabled()).toBe(true);
+      process.env[ENV_RECIPIENT_PAIRING] = "yes";
+      expect(isPairingEnabled()).toBe(false);
+      process.env[ENV_RECIPIENT_PAIRING] = "1";
+      expect(isPairingEnabled()).toBe(false);
+    });
+  });
+
+  describe("getPairedPath", () => {
+    it("rejects a non-absolute override", () => {
+      process.env[ENV_PAIRED_PATH] = "relative/paired.json";
+      expect(() => getPairedPath()).toThrow(/must be an absolute path/);
+    });
+
+    it("returns the override when absolute", () => {
+      expect(getPairedPath()).toBe(join(tmpDir, "paired.json"));
+    });
+  });
+
+  describe("add / remove / read", () => {
+    it("treats a fresh install as an empty list", () => {
+      expect(readPairedList()).toEqual([]);
+    });
+
+    it("adds an address and normalises case + whitespace", () => {
+      const r = addPairedAddress("  Alice@Example.COM  ");
+      expect(r).toEqual({ added: true, address: "alice@example.com" });
+      expect(readPairedList()).toEqual(["alice@example.com"]);
+    });
+
+    it("returns added:false on duplicate (no write, no rewrite)", () => {
+      addPairedAddress("bob@example.com");
+      const second = addPairedAddress("BOB@example.com");
+      expect(second).toEqual({ added: false, address: "bob@example.com" });
+      expect(readPairedList()).toEqual(["bob@example.com"]);
+    });
+
+    it("rejects strings that do not look like an email", () => {
+      expect(() => addPairedAddress("")).toThrow(/not a valid email/);
+      expect(() => addPairedAddress("plainstring")).toThrow(/not a valid email/);
+    });
+
+    it("keeps the paired list sorted on insert", () => {
+      addPairedAddress("charlie@example.com");
+      addPairedAddress("alice@example.com");
+      addPairedAddress("bob@example.com");
+      expect(readPairedList()).toEqual([
+        "alice@example.com",
+        "bob@example.com",
+        "charlie@example.com",
+      ]);
+    });
+
+    it("removes a paired address", () => {
+      addPairedAddress("alice@example.com");
+      addPairedAddress("bob@example.com");
+      expect(removePairedAddress("Alice@example.com")).toEqual({
+        removed: true,
+        address: "alice@example.com",
+      });
+      expect(readPairedList()).toEqual(["bob@example.com"]);
+    });
+
+    it("returns removed:false for an unknown address", () => {
+      expect(removePairedAddress("ghost@example.com")).toEqual({
+        removed: false,
+        address: "ghost@example.com",
+      });
+    });
+
+    it("writes the file at mode 0o600", () => {
+      addPairedAddress("alice@example.com");
+      const mode = statSync(getPairedPath()).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+
+    it("re-applies 0o600 even if the file pre-existed with a different mode", () => {
+      writeFileSync(
+        getPairedPath(),
+        JSON.stringify({ version: 1, addresses: [], updatedAt: new Date().toISOString() }),
+        { mode: 0o644 },
+      );
+      addPairedAddress("alice@example.com");
+      const mode = statSync(getPairedPath()).mode & 0o777;
+      expect(mode).toBe(0o600);
+    });
+  });
+
+  describe("isAddressPaired", () => {
+    it("matches case-insensitively and after trim", () => {
+      addPairedAddress("alice@example.com");
+      expect(isAddressPaired("Alice@Example.com")).toBe(true);
+      expect(isAddressPaired("  alice@example.com  ")).toBe(true);
+      expect(isAddressPaired("bob@example.com")).toBe(false);
+    });
+
+    it("returns false on empty input rather than matching", () => {
+      addPairedAddress("alice@example.com");
+      expect(isAddressPaired("")).toBe(false);
+      expect(isAddressPaired("   ")).toBe(false);
+    });
+  });
+
+  describe("requirePairedRecipients", () => {
+    it("is a no-op when pairing is disabled (default)", () => {
+      expect(() =>
+        requirePairedRecipients(["stranger1@example.com", "stranger2@example.com"]),
+      ).not.toThrow();
+    });
+
+    it("allows every recipient when pairing is enabled and all are paired", () => {
+      addPairedAddress("alice@example.com");
+      addPairedAddress("bob@example.com");
+      process.env[ENV_RECIPIENT_PAIRING] = "true";
+      expect(() => requirePairedRecipients(["alice@example.com", "Bob@Example.com"])).not.toThrow();
+    });
+
+    it("throws listing every un-paired address when pairing is enabled", () => {
+      addPairedAddress("alice@example.com");
+      process.env[ENV_RECIPIENT_PAIRING] = "true";
+      expect(() =>
+        requirePairedRecipients(["alice@example.com", "eve@evil.com", "mallory@evil.com"]),
+      ).toThrow(/eve@evil\.com, mallory@evil\.com/);
+    });
+
+    it("tolerates an empty recipient list even when pairing is enabled", () => {
+      process.env[ENV_RECIPIENT_PAIRING] = "true";
+      expect(() => requirePairedRecipients([])).not.toThrow();
+    });
+  });
+
+  describe("readPairedList validation", () => {
+    it("throws a clear error when the file is not valid JSON", () => {
+      writeFileSync(getPairedPath(), "{ not json ");
+      expect(() => readPairedList()).toThrow(/not valid JSON/);
+    });
+
+    it("throws a clear error when the file has the wrong shape", () => {
+      writeFileSync(getPairedPath(), JSON.stringify({ version: 2, addresses: ["a@b.com"] }));
+      expect(() => readPairedList()).toThrow(/expected .* shape/);
+    });
+
+    it("is tolerant of a freshly written file (round-trip)", () => {
+      addPairedAddress("alice@example.com");
+      const raw = readFileSync(getPairedPath(), "utf-8");
+      const parsed = JSON.parse(raw);
+      expect(parsed.version).toBe(1);
+      expect(parsed.addresses).toEqual(["alice@example.com"]);
+      expect(typeof parsed.updatedAt).toBe("string");
+    });
+  });
+});

--- a/src/recipient-pairing.ts
+++ b/src/recipient-pairing.ts
@@ -1,0 +1,163 @@
+/**
+ * Recipient pairing gate for write tools.
+ *
+ * Caps the blast radius of a prompt-injected `send_email` / `reply_all`
+ * / `draft_email` call: when `GMAIL_MCP_RECIPIENT_PAIRING=true`, every
+ * `To` / `Cc` / `Bcc` address must appear in an operator-maintained
+ * allowlist (`~/.gmail-mcp/paired.json` by default, overridable via
+ * `GMAIL_MCP_PAIRED_PATH`). The operator pairs addresses out-of-band
+ * (via the `pair_recipient` tool or by editing the file), so a
+ * hostile email asking the agent to send its inbox to
+ * `attacker@evil.example` cannot reach Gmail — it is rejected before
+ * the API call.
+ *
+ * Design notes:
+ * - Addresses are stored and compared case-insensitively (email local
+ *   parts are case-sensitive per RFC 5321 in theory, but every
+ *   mainstream provider including Gmail folds case, so matching on
+ *   lowercased values avoids `Alice@X.com` vs `alice@x.com` drift).
+ * - The file is written at mode `0o600` to match the rest of
+ *   `~/.gmail-mcp/`. The parent directory is created at mode `0o700`
+ *   if it does not already exist.
+ * - The feature is OFF by default — legacy users are not broken by
+ *   the install. Turning it on requires one explicit env flag plus
+ *   at least one `pair_recipient` call to avoid a "fresh install
+ *   refuses every send" lockout.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { homedir } from "node:os";
+
+export const ENV_RECIPIENT_PAIRING = "GMAIL_MCP_RECIPIENT_PAIRING";
+export const ENV_PAIRED_PATH = "GMAIL_MCP_PAIRED_PATH";
+
+export function isPairingEnabled(): boolean {
+  return process.env[ENV_RECIPIENT_PAIRING] === "true";
+}
+
+export function getPairedPath(): string {
+  const override = process.env[ENV_PAIRED_PATH];
+  if (override && override.trim() !== "") {
+    if (!path.isAbsolute(override)) {
+      throw new Error(`${ENV_PAIRED_PATH} must be an absolute path; got: ${override}`);
+    }
+    return override;
+  }
+  return path.join(homedir(), ".gmail-mcp", "paired.json");
+}
+
+interface PairedFile {
+  version: 1;
+  addresses: string[]; // stored lowercased
+  updatedAt: string; // ISO-8601
+}
+
+function isPairedFile(value: unknown): value is PairedFile {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  return (
+    v.version === 1 &&
+    Array.isArray(v.addresses) &&
+    v.addresses.every((a) => typeof a === "string") &&
+    typeof v.updatedAt === "string"
+  );
+}
+
+export function readPairedList(): string[] {
+  const file = getPairedPath();
+  if (!fs.existsSync(file)) return [];
+  let raw: string;
+  try {
+    raw = fs.readFileSync(file, "utf-8");
+  } catch (err) {
+    throw new Error(`Unable to read paired-recipients file at ${file}: ${(err as Error).message}`, {
+      cause: err,
+    });
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Paired-recipients file at ${file} is not valid JSON: ${(err as Error).message}`,
+      { cause: err },
+    );
+  }
+  if (!isPairedFile(parsed)) {
+    throw new Error(
+      `Paired-recipients file at ${file} does not match the expected { version:1, addresses:string[], updatedAt:string } shape.`,
+    );
+  }
+  return parsed.addresses;
+}
+
+function writePairedList(addresses: string[]): void {
+  const file = getPairedPath();
+  fs.mkdirSync(path.dirname(file), { recursive: true, mode: 0o700 });
+  const payload: PairedFile = {
+    version: 1,
+    addresses,
+    updatedAt: new Date().toISOString(),
+  };
+  fs.writeFileSync(file, JSON.stringify(payload, null, 2), { mode: 0o600 });
+  // fs.writeFileSync honours `mode` only on CREATE — chmod after to
+  // keep the mode right on a pre-existing file too.
+  fs.chmodSync(file, 0o600);
+}
+
+export function isAddressPaired(email: string): boolean {
+  const needle = email.trim().toLowerCase();
+  if (!needle) return false;
+  return readPairedList().includes(needle);
+}
+
+export function addPairedAddress(email: string): { added: boolean; address: string } {
+  const normalised = email.trim().toLowerCase();
+  if (!normalised || !normalised.includes("@")) {
+    throw new Error(`"${email}" is not a valid email address.`);
+  }
+  const current = readPairedList();
+  if (current.includes(normalised)) {
+    return { added: false, address: normalised };
+  }
+  writePairedList([...current, normalised].sort());
+  return { added: true, address: normalised };
+}
+
+export function removePairedAddress(email: string): { removed: boolean; address: string } {
+  const normalised = email.trim().toLowerCase();
+  const current = readPairedList();
+  const next = current.filter((a) => a !== normalised);
+  if (next.length === current.length) {
+    return { removed: false, address: normalised };
+  }
+  writePairedList(next);
+  return { removed: true, address: normalised };
+}
+
+/**
+ * Throw if any of `recipients` is not in the paired allowlist AND the
+ * feature is enabled. When the feature is disabled (default), this is
+ * a no-op — the existing send/reply/draft path is preserved verbatim.
+ *
+ * Error message lists every un-paired address so the operator (or the
+ * human in a human-in-the-loop flow) sees exactly which ones to pair.
+ */
+export function requirePairedRecipients(recipients: readonly string[]): void {
+  if (!isPairingEnabled()) return;
+  if (recipients.length === 0) return;
+  const paired = new Set(readPairedList());
+  const rejected: string[] = [];
+  for (const r of recipients) {
+    const normalised = r.trim().toLowerCase();
+    if (!normalised) continue;
+    if (!paired.has(normalised)) rejected.push(r.trim());
+  }
+  if (rejected.length === 0) return;
+  const plural = rejected.length === 1 ? "address is" : "addresses are";
+  throw new Error(
+    `Recipient pairing gate: ${rejected.length} ${plural} not in the paired allowlist at ${getPairedPath()} — ${rejected.join(", ")}. ` +
+      `Pair each address via the \`pair_recipient\` tool, or unset ${ENV_RECIPIENT_PAIRING} to disable the gate.`,
+  );
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -422,6 +422,20 @@ export const GetInboxWithThreadsSchema = z
     path: ["maxResults"],
   });
 
+// Recipient pairing gate schema — opt-in allowlist ops (add/remove/list).
+// Gate itself is enforced in handleEmailAction + reply_all when
+// GMAIL_MCP_RECIPIENT_PAIRING=true. See src/recipient-pairing.ts.
+export const PairRecipientSchema = z.object({
+  action: z
+    .enum(["add", "remove", "list"])
+    .describe("Operation on the paired-recipients allowlist"),
+  email: z
+    .string()
+    .max(512)
+    .optional()
+    .describe("Email address to add or remove. Required when action is add or remove."),
+});
+
 // Reply All schema - fetches original email and builds recipient list automatically
 export const ReplyAllSchema = z.object({
   messageId: GmailIdSchema.describe("ID of the email message to reply to"),
@@ -533,6 +547,16 @@ export const toolDefinitions: ToolDefinition[] = [
     schema: SendEmailSchema,
     scopes: ["gmail.modify", "gmail.compose", "gmail.send"],
     annotations: { title: "Send Email", destructiveHint: false },
+  },
+  {
+    name: "pair_recipient",
+    description:
+      "Manage the paired-recipient allowlist used by the GMAIL_MCP_RECIPIENT_PAIRING gate. Actions: add, remove, or list. When the gate is enabled, send_email/reply_all/draft_email reject any To/Cc/Bcc address not on this list.",
+    schema: PairRecipientSchema,
+    // Exposed wherever the send surface is; an operator with a
+    // readonly-only token has nothing to pair.
+    scopes: ["gmail.modify", "gmail.compose", "gmail.send", "mail.google.com"],
+    annotations: { title: "Pair Recipient", destructiveHint: false, idempotentHint: true },
   },
   {
     name: "draft_email",


### PR DESCRIPTION
## Summary

Opt-in allowlist that caps the blast radius of a prompt-injection-driven `send_email` / `reply_all` / `draft_email` call. Tracked in `ROADMAP.md` → v1.0.0 block as "Recipient pairing gate".

When `GMAIL_MCP_RECIPIENT_PAIRING=true`:
- Every `To` / `Cc` / `Bcc` address on the three send tools must appear in the paired allowlist
- Otherwise the call throws BEFORE reaching Gmail with a message listing every rejected address

Feature is **OFF by default** — legacy users see no change. Two explicit actions (set env + `pair_recipient add`) are needed to turn it on.

## New surface

### Storage

| | |
|---|---|
| Default path | `~/.gmail-mcp/paired.json`, mode `0o600` |
| Override | `GMAIL_MCP_PAIRED_PATH` (must be absolute) |
| Shape | `{ version: 1, addresses: string[] (lowercased, sorted), updatedAt: ISO-8601 }` |
| Parent dir | auto-created at `0o700` on first write |
| Mode enforcement | `0o600` re-applied on every write (handles pre-existing files) |

### New tool: `pair_recipient`

| Arg | Type | |
|---|---|---|
| `action` | `"add"` / `"remove"` / `"list"` | required |
| `email` | string (max 512) | required for add/remove, ignored for list |

Scopes mirror `send_email` — an operator with `gmail.readonly` only has nothing to pair. Returns `structuredContent` on every action for programmatic consumers.

### Gate integration

A single `requirePairedRecipients([...to, ...cc, ...bcc])` call at the top of `handleEmailAction` (`src/index.ts`) covers `send_email`, `draft_email`, AND `reply_all` (which delegates to `handleEmailAction`).

When the feature flag is off, the helper is a no-op — the send path is preserved verbatim.

## Normalisation

Addresses are lowercased + trimmed for storage and comparison. Every mainstream email provider folds local-part case in practice even though RFC 5321 leaves it implementation-defined.

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean (+5.9 KB in the bundle: new helper + new tool case)
- [x] `npm test` — **410 tests pass** (was 388; **22 new** in `src/recipient-pairing.test.ts` covering env toggling, file-mode guarantees, sort-on-insert, case-insensitive match, gate on/off behaviour, JSON-validation errors)
- [x] `npx prettier --check` clean
- [ ] CodeRabbit review clean

## Non-goals

- **Not** turning the feature on by default — that's a breaking change that must ship on a major.
- **Not** handling Gmail group / distribution-list aliases — if `team@company.com` expands to 20 addresses server-side, only `team@company.com` needs pairing. The individual expansion is opaque to the MCP and is Google's responsibility.
- **Not** blocking `batch_modify_emails` / `batch_delete_emails` — those act on message IDs, not recipients.