### PR TITLE
docs(readme): emoji-tag headings (Docker MCP style)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,25 +1,31 @@
-# Contributing
+# 🤝 Contributing
 
 PRs welcome. Please open an issue first for substantial changes (new tool, breaking behavior change, or anything touching the OAuth flow).
 
-## Before submitting a PR
+## ✅ Before submitting a PR
 
-1. `npm install` then `npm test` (all tests must stay green)
-2. `npm run build` (must succeed — the published tarball is a single-file `dist/index.js` produced by `tsup`)
-3. `npm run lint` (must be clean)
-4. `npm run format:check` (or run `npm run format` to reformat)
-5. Update `CHANGELOG.md` under `[Unreleased]`
-6. If you add or rename a tool, update the `Tools` section in the README and the entry in `src/tools.ts` (`toolDefinitions` array) — including the correct `scopes` and the `readOnlyHint` / `destructiveHint` / `idempotentHint` annotations
-7. New file-path inputs must be routed through `resolveDownloadSavePath()` or `assertAttachmentPathAllowed()` (no raw `fs.writeFileSync(userPath, …)` — see `src/utl.ts` for the canonical jail helpers)
+1️⃣ `npm install` then `npm test` (all tests must stay green)
 
-## Developer Certificate of Origin
+2️⃣ `npm run build` (must succeed — the published tarball is a single-file `dist/index.js` produced by `tsup`)
+
+3️⃣ `npm run lint` (must be clean)
+
+4️⃣ `npm run format:check` (or run `npm run format` to reformat)
+
+5️⃣ Update `CHANGELOG.md` under `[Unreleased]`
+
+6️⃣ If you add or rename a tool, update the 🛠️ `Tools` section in the README and the entry in `src/tools.ts` (`toolDefinitions` array) — including the correct `scopes` and the `readOnlyHint` / `destructiveHint` / `idempotentHint` annotations
+
+7️⃣ New file-path inputs must be routed through `resolveDownloadSavePath()` or `assertAttachmentPathAllowed()` (no raw `fs.writeFileSync(userPath, …)` — see `src/utl.ts` for the canonical jail helpers)
+
+## ✍️ Developer Certificate of Origin
 
 Every commit must carry a `Signed-off-by:` trailer to certify compliance with [DCO 1.1](https://developercertificate.org/). The trailer is added automatically by `git commit -s` or our prepare-commit-msg hook.
 
-## CodeRabbit review policy
+## 🐰 CodeRabbit review policy
 
 Every PR must pass CodeRabbit's assertive review and obtain a formal `APPROVED` review state before merge (see `.coderabbit.yaml`). `@coderabbitai approve` is allowed only via the built-in auto-review flow; do not click "Commit suggestion" on inline diffs — CodeRabbit-authored commits deadlock branch protection on a solo-maintainer repo.
 
-## Releases (maintainers only)
+## 🚀 Releases (maintainers only)
 
 Release process is not yet automated on this repo (tracked — will match the `klodr/faxdrop-mcp` / `klodr/mercury-invoicing-mcp` pattern once the upstream npm package name transition is resolved).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# gmail-mcp
+# 📧 gmail-mcp
 
 > Read, search, send, draft, label, filter, and thread Gmail from any MCP-enabled AI assistant. Wraps the [Gmail API](https://developers.google.com/gmail/api) with scope-gated tools and in-process safeguards.
 
@@ -28,7 +28,7 @@
 
 A Model Context Protocol (MCP) server that lets AI assistants (Claude Desktop, Claude Code, Cursor, Continue, OpenClaw…) read and manage a Gmail account through scope-gated tools. Exposes the Gmail v1 API surface you actually need (messages, threads, labels, filters, attachments, drafts, reply-all) behind a single `npx` install.
 
-## Why this MCP?
+## ✨ Why this MCP?
 
 Comparison of the three maintained forks of the original Gmail MCP server, focusing on what an agent platform actually needs — prompt-injection safety, supply-chain integrity, and operational hygiene:
 
@@ -92,7 +92,7 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 
 `klodr/gmail-mcp` is the only one of the three with **(a)** source-path jails that make prompt-injection attachment exfiltration inert, **(b)** a modern supply chain (Scorecard, Socket, Sigstore), and **(c)** an in-repo review policy (`.coderabbit.yaml`) that every PR must pass before merge.
 
-## Installation
+## 📦 Installation
 
 ```bash
 npm install -g @klodr/gmail-mcp
@@ -106,16 +106,16 @@ npx -y @klodr/gmail-mcp
 
 Requires **Node.js 22+**.
 
-## Configuration
+## ⚙️ Configuration
 
-### 1. Google Cloud OAuth credentials
+### 1️⃣ Google Cloud OAuth credentials
 
 1. Open the [Google Cloud Console](https://console.cloud.google.com/).
 2. Create a project and enable the **Gmail API**.
 3. Under **APIs & Services → Credentials**, create an **OAuth 2.0 Client ID** (Desktop or Web). For Web, add `http://localhost:3000/oauth2callback` to the authorised redirect URIs.
 4. Download the JSON, rename it to `gcp-oauth.keys.json`, place it at `~/.gmail-mcp/gcp-oauth.keys.json` (or override with `GMAIL_OAUTH_PATH=/abs/path/gcp-oauth.keys.json`).
 
-### 2. Authenticate (once)
+### 2️⃣ Authenticate (once)
 
 ```bash
 npx -y @klodr/gmail-mcp auth --scopes=gmail.readonly
@@ -123,7 +123,7 @@ npx -y @klodr/gmail-mcp auth --scopes=gmail.readonly
 
 Always pass `--scopes` with the minimum you actually need — the MCP filters the tool list at startup based on the granted scopes, so a read-only token doesn't expose write tools to the LLM. A browser opens for Google's consent flow; tokens are written to `~/.gmail-mcp/credentials.json` (mode `0o600`).
 
-### 3. Register the server with your MCP client
+### 3️⃣ Register the server with your MCP client
 
 ```json
 {
@@ -145,7 +145,7 @@ Client-specific config file:
 
 See [llms-install.md](./llms-install.md) for an LLM-readable install guide.
 
-## OAuth scopes
+## 🔑 OAuth scopes
 
 | Scope shorthand | Full Gmail scope | What it grants |
 |---|---|---|
@@ -178,7 +178,7 @@ npx @klodr/gmail-mcp auth --scopes=gmail.modify,gmail.settings.basic
 npx @klodr/gmail-mcp auth --scopes=gmail.modify,mail.google.com,gmail.settings.basic
 ```
 
-## Safeguards
+## 🛡️ Safeguards
 
 | Knob | Env var | Default | Notes |
 |---|---|---|---|
@@ -192,7 +192,7 @@ npx @klodr/gmail-mcp auth --scopes=gmail.modify,mail.google.com,gmail.settings.b
 | Audit log | `GMAIL_MCP_AUDIT_LOG=/abs/path/audit.jsonl` | unset (no audit trail) | Opt-in append-only JSONL log of every tool call (name, redacted args, outcome). File mode `0o600`. Must be an absolute path; relative paths are rejected at startup. Redaction keeps structural keys and drops values under an allowlist. |
 | Dry-run | `GMAIL_MCP_DRY_RUN=true` | unset (real calls) | When `"true"` (strict match), every write tool (`send_email`, `reply_all`, `draft_email`, `delete_email`, `modify_email`, `batch_modify_emails`, `batch_delete_emails`, `create_label`, `update_label`, `delete_label`, `get_or_create_label`, `create_filter`, `delete_filter`, `create_filter_from_template`, `modify_thread`) short-circuits before reaching Gmail and returns the redacted payload it would have sent. Useful for CI smoke tests, agent debugging, and human-in-the-loop approval flows. Read tools ignore the flag (nothing to preview). Matches `MERCURY_MCP_DRY_RUN` / `FAXDROP_MCP_DRY_RUN` on the sibling servers. |
 
-## Tools
+## 🛠️ Tools
 
 The exact set depends on the OAuth scopes granted at `auth` time. Full catalog:
 
@@ -203,35 +203,35 @@ The exact set depends on the OAuth scopes granted at `auth` time. Full catalog:
 
 Every write tool is annotated with `destructiveHint` / `readOnlyHint` / `idempotentHint` per the MCP spec so policy-aware clients can gate on HITL confirmation.
 
-### `search_emails` query syntax
+### 🔍 `search_emails` query syntax
 
 `search_emails` accepts Gmail's native search operators — `from:`, `to:`, `subject:`, `has:attachment`, `after:YYYY/MM/DD`, `before:YYYY/MM/DD`, `is:unread`, `label:<name>`, etc. They combine freely: `from:alice@example.com after:2026/01/01 has:attachment`. Full reference: [Google's Gmail search operators cheat sheet](https://support.google.com/mail/answer/7190).
 
-## Roadmap
+## 🗺️ Roadmap
 
 See [ROADMAP.md](./ROADMAP.md).
 
-## Ecosystem
+## 🌐 Ecosystem
 
 The wider Gmail-MCP landscape — 29 standalone repositories and 323 forks of the original GongRzhe server — is reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md). That page covers which ideas we borrowed, which we chose not to, and where `klodr/gmail-mcp` sits on the maturity axes.
 
-## Contributing
+## 🤝 Contributing
 
 See [CONTRIBUTING.md](./CONTRIBUTING.md) for the test / build / lint checklist and release process.
 
-## Security
+## 🔒 Security
 
 See [SECURITY.md](./SECURITY.md) for the vulnerability-reporting process and the current security model, and [ASSURANCE_CASE.md](./ASSURANCE_CASE.md) for the threat model, trust boundaries, and CWE/OWASP mitigation table.
 
-## Project continuity
+## 📋 Project continuity
 
 See [CONTINUITY.md](./CONTINUITY.md) for the handover plan if the maintainer becomes unavailable.
 
-## License
+## 📄 License
 
 MIT — see [LICENSE](./LICENSE).
 
-## History
+## 📜 History
 
 `klodr/gmail-mcp` is the maintenance fork of a two-step upstream chain:
 


### PR DESCRIPTION
## Summary

Apply the Docker-MCP-style visual charter to `README.md` and `CONTRIBUTING.md` — every H2/H3 heading gets a single leading emoji so the outline renders as a legible icon list in the GitHub file preview and on the Docker MCP registry landing.

### README.md mapping

| Heading | Tag |
|---|---|
| Title `gmail-mcp` | 📧 |
| Why this MCP? | ✨ |
| Installation | 📦 |
| Configuration | ⚙️ |
| 1. Google Cloud OAuth credentials | 1️⃣ |
| 2. Authenticate (once) | 2️⃣ |
| 3. Register the server with your MCP client | 3️⃣ |
| OAuth scopes | 🔑 |
| Safeguards | 🛡️ |
| Tools | 🛠️ |
| `search_emails` query syntax | 🔍 |
| Roadmap | 🗺️ |
| Ecosystem | 🌐 |
| Contributing | 🤝 |
| Security | 🔒 |
| Project continuity | 📋 |
| License | 📄 |
| History | 📜 |

### CONTRIBUTING.md mapping

| Heading | Tag |
|---|---|
| Title | 🤝 |
| Before submitting a PR | ✅ |
| `1.` … `7.` numbered items | 1️⃣ … 7️⃣ (with blank lines between for renderer) |
| Developer Certificate of Origin | ✍️ |
| CodeRabbit review policy | 🐰 |
| Releases (maintainers only) | 🚀 |

## Test plan

- [x] `npx prettier --check` clean
- [x] No source changes; docs-only
- [ ] CodeRabbit review clean