### PR TITLE
ci(workflows): enable merge_group trigger for Merge Queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  merge_group:
   schedule:
     - cron: "0 6 * * 1"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,7 @@ on:
       - "tsconfig.json"
       - "tsup.config.ts"
       - ".github/workflows/docker.yml"
+  merge_group:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Add the `merge_group:` event trigger to the three workflows that run as required status checks on PRs (`ci.yml`, `codeql.yml`, `docker.yml`) so GitHub Merge Queue can dispatch them on the shadow branch.

Without this trigger, required checks never start on queued PRs and the queue blocks.

## Scope

- `ci.yml` — required (lint / build / test)
- `codeql.yml` — required (security scan)
- `docker.yml` — required (image build + OCI labels + smoke test)

`qodo-merge.yml` is intentionally left on `pull_request`-only: it is an AI review, not a shadow-branch validation check. Running it in the queue would consume API budget without adding signal.

## Next step (manual, UI)

Once merged, enable Merge Queue on `main` via Settings → Rules → Rulesets → edit main ruleset → **Require merge queue**, with:
- Merge method: **squash**
- Wait time: 5 min
- Required checks: the ones above

## Test plan

- [ ] CI green on this PR (same triggers as before — `merge_group` is additive)
- [ ] After merge, adding a trivial follow-up PR to the Merge Queue fires `ci`, `codeql`, `docker` on the shadow branch