### PR TITLE
chore(release): v0.20.0 — Security release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-04-25 — Security release
+
+A minor-version jump from `0.10.0` (skipping `0.11`–`0.19`) signals the
+weight of hardening packed into this release: the headline is the **opt-in
+recipient-pairing gate** that caps the blast radius of a prompt-injection
+on `send_email` / `reply_all` / `draft_email`, joined by community-health
+infrastructure, repo-root cleanup, and the npm-tarball discoverability
+fixes that landed since `0.10.0`. No breaking change for legacy users
+(every safety gate is opt-in via env var). `1.0.0` is reserved for the
+`Server` → `McpServer` SDK migration tracked in `docs/ROADMAP.md`.
+
 ### Added
 
 - **Recipient pairing gate** — opt-in allowlist that caps the blast radius of a prompt-injection-driven `send_email` / `reply_all` / `draft_email` call. When `GMAIL_MCP_RECIPIENT_PAIRING=true`, every `To` / `Cc` / `Bcc` address must appear in `~/.gmail-mcp/paired.json` (mode `0o600`, override via `GMAIL_MCP_PAIRED_PATH`). Manage the list via the new `pair_recipient` tool (`action: "add" | "remove" | "list"`). Feature is OFF by default; legacy users see no change. Tracked in `docs/ROADMAP.md` → v1.0.0 block.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.9.2",
+  "version": "0.20.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klodr/gmail-mcp",
-      "version": "0.9.2",
+      "version": "0.20.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.10.0",
+  "version": "0.20.0",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "0.10.0",
+  "version": "0.20.0",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "0.10.0",
+      "version": "0.20.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -500,7 +500,7 @@ async function main() {
   const server = new Server(
     {
       name: "gmail",
-      version: "0.10.0",
+      version: "0.20.0",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary

Cuts **v0.20.0** from main. A minor-version jump from `0.10.0` (skipping `0.11`–`0.19`) signals the weight of hardening packed into this release.

The headline feature is the **opt-in recipient-pairing gate** that caps the blast radius of a prompt-injection-driven `send_email` / `reply_all` / `draft_email`. Joined by community-health infrastructure, repo-root cleanup, and the npm-tarball discoverability fixes shipped since `0.10.0`.

**No breaking change for legacy users** — every safety gate is opt-in via env var. `1.0.0` is reserved for the `Server` → `McpServer` SDK migration tracked in `docs/ROADMAP.md`.

## 🛡️ Security highlights

- **Recipient pairing gate** — when `GMAIL_MCP_RECIPIENT_PAIRING=true`, every `To` / `Cc` / `Bcc` address must appear in `~/.gmail-mcp/paired.json` (mode `0o600`). New `pair_recipient` tool (`add` / `remove` / `list`). OFF by default.
- **Three error-surface catches** in `src/index.ts` now consume `asGmailApiError`, surfacing Gmail HTTP status in user-facing errors (vs swallowing them).
- **`attachStructuredContent` pre-filter** — middleware short-circuits non-JSON tool output instead of `try/catch`-rejecting it. Cheaper + clearer security boundary.

## 📦 Community / packaging

- `.github/SUPPORT.md` (issue-redirection page) + `CITATION.cff` (GitHub "Cite" button) + `.github/FUNDING.yml` (Sponsor button).
- `package.json` `funding: https://github.com/sponsors/klodr` + `CHANGELOG.md` added to `files` allowlist (npm v11 fix).
- `.env.example` documenting all `GMAIL_MCP_*` env vars.
- `.github/social-preview.png` — repo Open Graph image.

## 🧹 Repo structure

- Community files (`CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`) → `.github/`.
- General docs (`ROADMAP.md`, `ASSURANCE_CASE.md`, `CONTINUITY.md`) → `docs/`.
- Internal links updated (12 files), including `socket.yml`, `codecov.yml`, workflows, `src/{index,sanitize,gmail-errors}.ts`.
- `.npmignore` removed (was misleading — `package.json` `files` is in whitelist mode, npm ignores `.npmignore` entirely).

## 🚀 Performance

- `download_email` parallelises Gmail metadata + raw-EML fetches when `format: "eml"` (was serial → halves user-visible latency on EML saves).

## Release plan

After merge:
1. `git tag -s v0.20.0 && git push origin v0.20.0`
2. `release.yml` extracts the matching CHANGELOG section, signs `dist/index.js` with Sigstore, publishes to npm with provenance.
3. `verify-release.yml` re-exercises the three verification paths (npm CLI provenance, `gh attestation verify`, `cosign verify-blob-attestation`).