### PR TITLE
fix(deps): pin packageManager + move gaxios to devDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "email-addresses": "^5.0.0",
+        "gaxios": "^7.1.4",
         "google-auth-library": "^10.6.2",
         "googleapis": "^171.4.0",
         "nodemailer": "^8.0.5",
@@ -35,7 +36,10 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=22.11"
+        "node": ">=22.22.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/klodr"
       }
     },
     "node_modules/@babel/helper-string-parser": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
         "email-addresses": "^5.0.0",
-        "gaxios": "^7.1.4",
         "google-auth-library": "^10.6.2",
         "googleapis": "^171.4.0",
         "nodemailer": "^8.0.5",
@@ -29,6 +28,7 @@
         "eslint": "^10.2.1",
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.7.0",
+        "gaxios": "^7.1.4",
         "prettier": "^3.8.3",
         "tsup": "^8.5.1",
         "typescript": "^6.0.3",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   "engines": {
     "node": ">=22.22.2"
   },
+  "packageManager": "npm@11.12.1",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "email-addresses": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -59,10 +59,11 @@
   "engines": {
     "node": ">=22.22.2"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@10.9.7",
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "email-addresses": "^5.0.0",
+    "gaxios": "^7.1.4",
     "google-auth-library": "^10.6.2",
     "googleapis": "^171.4.0",
     "nodemailer": "^8.0.5",
@@ -82,5 +83,10 @@
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.58.2",
     "vitest": "^4.1.5"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
     "email-addresses": "^5.0.0",
-    "gaxios": "^7.1.4",
     "google-auth-library": "^10.6.2",
     "googleapis": "^171.4.0",
     "nodemailer": "^8.0.5",
@@ -78,6 +77,7 @@
     "eslint": "^10.2.1",
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.7.0",
+    "gaxios": "^7.1.4",
     "prettier": "^3.8.3",
     "tsup": "^8.5.1",
     "typescript": "^6.0.3",


### PR DESCRIPTION
## Summary

Three related changes to `package.json`, uncovered by Glama's pnpm-based build (test 019db7ae, 2026-04-23, gmail-mcp v0.9.1):

1. **Pin `packageManager` to `npm@10.9.7`** so Corepack-enabled environments install a deterministic npm.
2. **Move `gaxios` from `dependencies` to `devDependencies`** (per CodeRabbit review on this PR — `gaxios` is only used as a type-only import).
3. **Add `pnpm.onlyBuiltDependencies: ["esbuild"]`** so pnpm-based registries can build without operator-prompt for esbuild's post-install.

## 1. `packageManager: npm@10.9.7`

`package-lock.json` is in lockfileVersion 3 (generated by npm 9+). Without the `packageManager` field, a contributor or CI runner with an older npm could regenerate a lockfileVersion 2 lockfile on `npm install`, breaking install reproducibility.

With Corepack enabled, the field auto-installs and uses the exact npm version. Without Corepack, the field is silently ignored.

`npm@10.9.7` matches the npm version bundled with Node 22.22.2 (our `engines.node` floor). Earlier draft of this PR was `npm@11.12.1`, but that would force Corepack to download a different npm than what every Node 22 install ships with — strictly worse.

## 2. `gaxios` → devDependencies

`src/gmail-errors.ts:12` is the sole usage:

```ts
import type { GaxiosError } from "gaxios";
```

`tsup.config.ts` has `dts: false`, so no `.d.ts` is shipped to consumers and the type-only import is fully erased at build time. There is no runtime `require` of `gaxios` in the published tarball.

The original Glama TS2307 failure (`Cannot find module 'gaxios'`) is still fixed because devDependencies are installed at build time even under pnpm's strict isolation. The original bug was that `gaxios` was neither in dependencies nor in devDependencies, leaving it resolvable only via transitive hoisting which pnpm refuses.

## 3. `pnpm.onlyBuiltDependencies: ["esbuild"]`

pnpm refuses post-install scripts by default (security hardening, v9+). `esbuild` (a `tsup` transitive) needs its own post-install hook to fetch the platform-specific binary. Allow-listing `esbuild` keeps pnpm-based registries unblocked while all other transitive post-install scripts stay blocked. npm and yarn ignore this field.

## Compatibility check

- ✅ Docker MCP Registry — consumes `Dockerfile`, ignores both fields.
- ✅ Glama — pnpm honors the allow-list; gaxios resolves at top-level (devDep, installed at build time).
- ✅ Smithery — consumes `smithery.yaml` + npx invocation, ignores both fields.
- ✅ npm install without Corepack — both fields silently ignored.

## Test plan

- [x] `npm install --package-lock-only` regenerates lockfile cleanly
- [x] `npm test` green (412/412)
- [x] `npm run build` green (gaxios as devDep does not break the build)
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [ ] Glama re-build with the same pnpm-based config should succeed
