### PR TITLE
fix(boot): boot in lazy-auth mode when OAuth keys are missing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -120,7 +120,13 @@ jobs:
               echo "Startup OK (exit=124 — stdin wait)"
               ;;
             0)
-              if echo "$out" | grep -qEi "lazy-auth mode|gcp-oauth\.keys|GMAIL_OAUTH_PATH"; then
+              # Tighten the guard: require the explicit lazy-auth warning,
+              # not just any mention of the OAuth keys path. The previous
+              # broader pattern accepted stderr that mentioned the path
+              # name without proving the lazy-boot branch actually fired
+              # — a real crash that happened to print the path during
+              # error formatting would have slipped through (CR finding).
+              if echo "$out" | grep -qF "booting in lazy-auth mode"; then
                 echo "Startup OK (exit=0 — lazy-auth boot, stdin EOF closed transport)"
               else
                 echo "Exit 0 without the expected lazy-auth warning — real crash or wrong entrypoint" >&2

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,16 +92,23 @@ jobs:
           fi
 
       - name: Smoke-test (container is executable and reaches the entrypoint)
-        # The stdio MCP server blocks on stdin. Healthy outcomes are
-        # either:
-        #   - exit 1: fail-fast when no gcp-oauth.keys.json is present
-        #     (no credentials volume mounted — the container refuses
-        #     to start). Must be accompanied by an error message
-        #     mentioning gcp-oauth.keys or GMAIL_OAUTH_PATH.
+        # The stdio MCP server blocks on stdin. Healthy outcomes are:
         #   - exit 124: `timeout` killed the process while it was
-        #     waiting on stdin for a JSON-RPC frame (would happen if
-        #     credentials WERE present, which CI never ships).
-        # Any other exit code fails CI so a broken entrypoint cannot
+        #     waiting on stdin for a JSON-RPC frame (the standard
+        #     happy-path when stdin stays open).
+        #   - exit 0 with the "lazy-auth mode" warning: lazy-boot
+        #     branch (no gcp-oauth.keys.json present) — the server
+        #     booted, registered handlers, then stdin EOF closed the
+        #     transport cleanly. This is the expected path on hosted
+        #     MCP runners (Glama, Smithery, Docker MCP Registry) that
+        #     run a `tools/list` smoke test before any credentials
+        #     volume is mounted. Must be accompanied by the lazy-boot
+        #     warning so a silent crash cannot impersonate this case.
+        #   - exit 1 with the legacy missing-credentials message:
+        #     kept for backwards compatibility with any deployment
+        #     that still expects the pre-lazy-boot fail-fast shape;
+        #     the runtime no longer takes this path on a fresh boot.
+        # Any other outcome fails CI so a broken entrypoint cannot
         # silently ship.
         run: |
           set +e
@@ -112,16 +119,24 @@ jobs:
             124)
               echo "Startup OK (exit=124 — stdin wait)"
               ;;
+            0)
+              if echo "$out" | grep -qEi "lazy-auth mode|gcp-oauth\.keys|GMAIL_OAUTH_PATH"; then
+                echo "Startup OK (exit=0 — lazy-auth boot, stdin EOF closed transport)"
+              else
+                echo "Exit 0 without the expected lazy-auth warning — real crash or wrong entrypoint" >&2
+                exit 1
+              fi
+              ;;
             1)
               if echo "$out" | grep -qEi "gcp-oauth\.keys|GMAIL_OAUTH_PATH"; then
-                echo "Startup OK (exit=1 — fail-fast on missing OAuth keys)"
+                echo "Startup OK (exit=1 — legacy fail-fast on missing OAuth keys)"
               else
                 echo "Exit 1 without the expected missing-credentials error — real crash" >&2
                 exit 1
               fi
               ;;
             *)
-              echo "Unexpected exit code $ec — only 1 (with missing-credentials message) or 124 (stdin wait) are healthy" >&2
+              echo "Unexpected exit code $ec — only 0 (with lazy-auth warning), 1 (with missing-credentials message), or 124 (stdin wait) are healthy" >&2
               exit 1
               ;;
           esac

--- a/src/gmail-errors.test.ts
+++ b/src/gmail-errors.test.ts
@@ -97,6 +97,18 @@ describe("isInvalidGrantError", () => {
     expect(isInvalidGrantError(new Error("ECONNRESET"))).toBe(false);
   });
 
+  it("matches the lazy-boot stub OAuth2Client error shape", () => {
+    // Real google-auth-library text when `new OAuth2Client()` is queried
+    // without credentials. The lazy-boot path needs this to flow into
+    // the same INVALID_GRANT-shaped payload as a revoked refresh token.
+    expect(
+      isInvalidGrantError(
+        new Error("No access, refresh token, API key or refresh handler callback is set."),
+      ),
+    ).toBe(true);
+    expect(isInvalidGrantError(new Error("no credentials configured"))).toBe(true);
+  });
+
   it("returns false for non-Error throwables", () => {
     expect(isInvalidGrantError("invalid_grant")).toBe(false);
     expect(isInvalidGrantError(null)).toBe(false);

--- a/src/gmail-errors.ts
+++ b/src/gmail-errors.ts
@@ -68,17 +68,31 @@ export interface InvalidGrantPayload {
  */
 export function isInvalidGrantError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
-  const needle = "invalid_grant";
-  if (err.message.toLowerCase().includes(needle)) return true;
+  const lowerMsg = err.message.toLowerCase();
+  // Classic OAuth `invalid_grant` shape — Google's response on a
+  // revoked / expired / reissued refresh token.
+  if (lowerMsg.includes("invalid_grant")) return true;
+  // Lazy-boot stub case: when no OAuth keys file exists, the server
+  // boots with `new OAuth2Client()` (no credentials). The very first
+  // `getAccessToken()` (or any tool call) then throws something
+  // shaped like:
+  //   "No access, refresh token, API key or refresh handler callback is set"
+  // or simply "no credentials". The remediation for the operator is
+  // identical to the invalid_grant case (run `auth`), so collapse
+  // both into a single agent-visible payload via the same predicate
+  // (per CR finding on PR #79).
+  if (lowerMsg.includes("no access, refresh token") || lowerMsg.includes("no credentials")) {
+    return true;
+  }
   const data = (err as unknown as GaxiosError).response?.data as
     | { error?: unknown; error_description?: unknown }
     | undefined;
-  if (typeof data?.error === "string" && data.error.toLowerCase().includes(needle)) {
+  if (typeof data?.error === "string" && data.error.toLowerCase().includes("invalid_grant")) {
     return true;
   }
   if (
     typeof data?.error_description === "string" &&
-    data.error_description.toLowerCase().includes(needle)
+    data.error_description.toLowerCase().includes("invalid_grant")
   ) {
     return true;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,11 +234,22 @@ function loadCredentials() {
     }
 
     if (!fs.existsSync(OAUTH_PATH)) {
+      // Lazy-boot mode: no OAuth keys at startup. Hosted MCP runners
+      // (Glama, Smithery, etc.) run a smoke test on `tools/list` before
+      // the user has any chance to mount credentials, and exiting here
+      // would mark the server as broken on the registry. Boot with a
+      // stub OAuth2Client instead — `tools/list` (which does not touch
+      // gmail.users.*) succeeds, and any tool call that needs auth
+      // fails cleanly through the `asGmailApiError` path with an
+      // `INVALID_GRANT`-shaped payload that surfaces the missing-auth
+      // condition to the agent.
       console.error(
-        "Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or",
-        CONFIG_DIR,
+        "Warning: OAuth keys file not found at",
+        OAUTH_PATH,
+        "— booting in lazy-auth mode. Tool calls that need Gmail will fail until `npx @klodr/gmail-mcp auth` is run.",
       );
-      process.exit(1);
+      oauth2Client = new OAuth2Client();
+      return;
     }
 
     const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, "utf8"));


### PR DESCRIPTION
## Summary
Patch `loadCredentials()` to boot in lazy-auth mode when OAuth keys are missing, instead of `process.exit(1)`.

## Why
Hosted MCP runners (Glama, Smithery, Docker MCP Registry, etc.) run a `tools/list` smoke test against every server before any user has mounted credentials. With the current code, `gmail-mcp` dies on missing `gcp-oauth.keys.json` and the registry marks the server as broken — see today's Glama smoke-test failure:

```
2026-04-25T11:02:08 Error: OAuth keys file not found. Please place gcp-oauth.keys.json in current directory or /root/.gmail-mcp
2026-04-25T11:02:08 could not start the proxy McpError: MCP error -32000: Connection closed
```

This unblocks **item B of the Glama runbook** (`gmail-mcp Create Release`), which has been pending behind this exact failure mode.

## Behaviour
- **Missing OAuth file** → log a warning, instantiate a stub `OAuth2Client()`, return. Server boots normally.
- **`tools/list`** → succeeds (it does not touch `gmail.users.*`).
- **Tool call that needs Gmail** → fails through the existing `asGmailApiError` path with an `INVALID_GRANT`-shaped payload (`code: "INVALID_GRANT"`, `recovery_action: "Re-run npx @klodr/gmail-mcp auth ..."`) — agents see a clean auth-required surface instead of a stdio-level close.
- **Corrupt OAuth file** (catch block) → still `process.exit(1)`. That branch indicates a legitimate operator-config error the user should see at boot, not a missing-credentials situation.

## ROADMAP follow-up
The longer-term fix for this surface — full env-var-based OAuth (`GMAIL_OAUTH_CLIENT_ID` / `GMAIL_OAUTH_CLIENT_SECRET` / `GMAIL_OAUTH_REFRESH_TOKEN`) — is already tracked under `Headless OAuth mode for hosted deployments` in `docs/ROADMAP.md`. This patch is the minimum surface to unblock registry smoke tests today; the ROADMAP item adds the credentials path.

## Test plan
- [x] `npm test` — 412/412 pass
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] `npm run build` green
- [ ] CI green
- [ ] CodeRabbit + Qodo review
- [ ] Glama re-test on `gmail-mcp` Dockerfile passes after merge