### PR TITLE
fix(filters): gate create_filter.action.forward via recipient-pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | Release: npm provenance statement | ❌ | ❌ | ✅ |
 | Release: single-file `tsup` ESM bundle (smaller tarball, easier to verify) | ❌ (multi-file `tsc`) | ❌ (multi-file `tsc`) | ✅ (target `node22`, `ES2024`) |
 | **Testing** | | | |
-| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (386 tests) |
+| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (412 tests) |
 | Statement coverage across `src/**` | 0% | 16.14% | **>50%** |
 | Fast-check property-based fuzz suite | ❌ | ❌ | ✅ |
 | Hardening-specific test file (jails, CRLF, O_EXCL) | ❌ | ❌ | ✅ |

--- a/src/index.ts
+++ b/src/index.ts
@@ -1398,6 +1398,17 @@ async function main() {
           // Filter management handlers
           case "create_filter": {
             const validatedArgs = CreateFilterSchema.parse(args);
+            // The `action.forward` field installs a persistent server-side
+            // mail-forwarding rule. Gmail itself only allows forwarding to
+            // pre-verified addresses, but a prompt-injected agent on a
+            // settings.basic token could still pick any verified address —
+            // including one the human added long ago and forgot. Gate the
+            // forward action through the same recipient-pairing allowlist
+            // that protects send_email / reply_all / draft_email so the
+            // exfil channel stays closed when the gate is enabled.
+            if (validatedArgs.action.forward) {
+              requirePairedRecipients([validatedArgs.action.forward]);
+            }
             const result = await createFilter(gmail, validatedArgs.criteria, validatedArgs.action);
 
             // Format criteria for display

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -810,11 +810,11 @@ export const toolDefinitions: ToolDefinition[] = [
       "",
       "DO NOT USE: for common patterns (newsletter routing, vendor invoices, etc.) — `create_filter_from_template` covers those with safer defaults. Filters are not idempotent — calling twice creates two filters firing duplicate actions.",
       "",
-      "SIDE EFFECTS: writes a new filter rule on Gmail's side. Persistent. Affects every future incoming message that matches the criteria. Requires `gmail.settings.basic` scope.",
+      "SIDE EFFECTS: writes a new filter rule on Gmail's side. Persistent. Affects every future incoming message that matches the criteria. The optional `action.forward` field installs a persistent forwarding rule and is therefore gated by the same recipient-pairing allowlist as `send_email` / `reply_all` / `draft_email` when `GMAIL_MCP_RECIPIENT_PAIRING=true` — pair the address via `pair_recipient` first. Requires `gmail.settings.basic` scope.",
     ].join("\n"),
     schema: CreateFilterSchema,
     scopes: ["gmail.settings.basic"],
-    annotations: { title: "Create Filter", destructiveHint: false },
+    annotations: { title: "Create Filter", destructiveHint: true },
   },
   {
     name: "delete_filter",


### PR DESCRIPTION
## Summary
Close the two MEDIUM findings from today's Docker MCP Registry-style security review of `klodr/gmail-mcp`:

1. **`create_filter.action.forward` not gated by recipient-pairing** — the schema accepted any forwarding target, so a prompt-injected agent on a `gmail.settings.basic` token could install a persistent server-side forwarding rule to any pre-verified address. The recipient-pairing gate already protects `send_email` / `reply_all` / `draft_email`; this PR extends it to filter creation.

2. **`create_filter` shipped `destructiveHint: false`** — MCP hosts that auto-approve non-destructive tools never prompted the user before installing a filter that affects every future inbound message. Flipped to `true`.

## Behaviour
- With `GMAIL_MCP_RECIPIENT_PAIRING=true`: an unpaired `action.forward` target throws `PairedRecipientError` before any Gmail API call. Pair the address via `pair_recipient` first.
- Without the gate (default): no change in behaviour — same as before.
- `create_filter` calls without `action.forward` are unaffected.

## Files changed
- `src/index.ts` — `requirePairedRecipients([action.forward])` injected into the `create_filter` case before `createFilter()` is called.
- `src/tools.ts` — `destructiveHint: true` flip on the `create_filter` annotation. SIDE EFFECTS section in the description now mentions the gate.
- `README.md` — test count 386 → 412 (drift correction).

## Test plan
- [x] `npm test` — 412/412 pass
- [x] `npm run format:check` clean
- [x] `npm run lint` clean
- [x] Build green via `tsup`
- [ ] CI green (Docker smoke / Codecov / CodeRabbit / dual-Qodo)
- [ ] CodeRabbit + Qodo review

No regression for the unpaired-write surface — the gate fails closed only when explicitly enabled, exactly like the pre-existing send/reply/draft path.