### PR TITLE
release: v0.21.1 — Security review LOW/INFO findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,7 +240,8 @@ the 25-tool dispatcher (tracked in `ROADMAP.md`).
 
 This repository is a fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Pre-fork changelog is not reproduced here — see the upstream history and the acknowledgments in the README.
 
-[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v0.21.0...HEAD
+[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v0.21.1...HEAD
+[0.21.1]: https://github.com/klodr/gmail-mcp/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/klodr/gmail-mcp/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/klodr/gmail-mcp/compare/v0.10.0...v0.20.0
 [0.10.0]: https://github.com/klodr/gmail-mcp/compare/v0.9.2...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-04-26 — Security review LOW/INFO findings
+
+A patch release closing the six LOW/INFO findings raised by the
+`docker/mcp-registry` security-reviewer audit on `0.21.0`. Two findings
+target the lazy-auth boot path (now ships an empty tool surface and a
+clearer error class for unauthenticated calls), three close down email
+input validation (RFC 5322 parser as the single source of truth across
+`validateEmail`, the Zod `pair_recipient.email` schema, and the
+sanitization layer extended to U+2028/U+2029), and one hardens the
+OAuth callback's port handling. No breaking change. No new
+dependencies. The on-the-wire `tools/list` shape only changes when
+`gcp-oauth.keys.json` is missing (now `[]` instead of 26 unauthable
+tools) — clients with credentials see the identical 26-tool surface
+they had on `0.21.0`.
+
 ### Changed
 
 - **Lazy-auth boot now advertises an empty tool surface on `tools/list`** — when `gcp-oauth.keys.json` is missing, `loadCredentials` creates a stub `OAuth2Client` and now also resets `authorizedScopes` to `[]`. Previously `tools/list` returned all 26 tools, none of which could authenticate — misleading to agent operators inspecting capabilities pre-auth. `src/index.ts:203`. Closes the LOW finding in the v0.21.0 security review.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klodr/gmail-mcp",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/index.ts
+++ b/src/index.ts
@@ -501,7 +501,7 @@ async function main() {
   const server = new Server(
     {
       name: "gmail",
-      version: "0.21.0",
+      version: "0.21.1",
     },
     {
       capabilities: {


### PR DESCRIPTION
## Summary

Patch release closing the 6 LOW/INFO findings raised by the `docker/mcp-registry` security-reviewer audit on `0.21.0`.

## Highlights

- **Lazy-auth boot now ships an empty `tools/list`** when `gcp-oauth.keys.json` is missing (instead of 26 unauthable tools).
- **`validateEmail` delegates to `email-addresses.parseOneAddress`** — single RFC 5322 source of truth across the codebase, replacing the local regex.
- **`pair_recipient.email` Zod schema** now `.refine()`s through the same parser — malformed addresses rejected pre-dispatch.
- **`sanitizeHeaderValue`** strip-set extended to `U+2028` / `U+2029` (LINE / PARAGRAPH SEPARATOR).
- **MIME-tree walkers depth-bounded** at `MAX_MIME_DEPTH = 32` — drops sub-parts and emits a structured `mime_depth_exceeded` warning beyond the cap.
- **OAuth callback port range-checked** (`1024–65535`) + dedicated `error` listener on `server.listen` for clean `EADDRINUSE` / `EACCES` surfacing.

No breaking change. No new runtime dependencies. Clients with credentials see the identical 26-tool surface they had on `0.21.0`.

## Tests

- Baseline: 412 (pre-fix)
- Now: **440 passed** (+28 covering the new walkers, validators, and lazy-boot path)

## Checklist

- [x] Title ≤ 72 chars
- [x] CHANGELOG.md updated (`[Unreleased]` → `[0.21.1] - 2026-04-26`)
- [x] `npm version 0.21.1` synced `server.json` + `src/index.ts`
- [x] `npm test` green
- [x] Signed commit