### PR TITLE
refactor(server): extract email-send + batch helpers + extractHeaders

### DIFF
--- a/src/batch.test.ts
+++ b/src/batch.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { processBatches } from "./batch.js";
+
+describe("processBatches", () => {
+  it("returns empty outcome for an empty input list", async () => {
+    const fn = vi.fn(async (batch: number[]) => batch);
+    const result = await processBatches([], 10, fn);
+    expect(result.successes).toEqual([]);
+    expect(result.failures).toEqual([]);
+    expect(fn).not.toHaveBeenCalled();
+  });
+
+  it("processes every item in a single happy-path batch", async () => {
+    const items = [1, 2, 3];
+    const fn = vi.fn(async (batch: number[]) => batch.map((n) => n * 10));
+    const result = await processBatches(items, 10, fn);
+    expect(result.successes).toEqual([10, 20, 30]);
+    expect(result.failures).toEqual([]);
+    expect(fn).toHaveBeenCalledTimes(1);
+    expect(fn).toHaveBeenCalledWith([1, 2, 3]);
+  });
+
+  it("respects batchSize and issues one call per chunk", async () => {
+    const items = [1, 2, 3, 4, 5];
+    const fn = vi.fn(async (batch: number[]) => batch);
+    await processBatches(items, 2, fn);
+    expect(fn).toHaveBeenCalledTimes(3);
+    expect(fn).toHaveBeenNthCalledWith(1, [1, 2]);
+    expect(fn).toHaveBeenNthCalledWith(2, [3, 4]);
+    expect(fn).toHaveBeenNthCalledWith(3, [5]);
+  });
+
+  it("falls back to per-item retry when a batch throws, surfacing partial success", async () => {
+    const items = [1, 2, 3];
+    let call = 0;
+    const fn = vi.fn(async (batch: number[]) => {
+      call += 1;
+      // First call (the whole batch) throws; subsequent per-item calls
+      // succeed for items 1 and 3, throw for item 2.
+      if (call === 1) throw new Error("whole batch failed");
+      if (batch.length === 1 && batch[0] === 2) throw new Error("item 2 is poison");
+      return batch.map((n) => n * 100);
+    });
+
+    const result = await processBatches(items, 3, fn);
+    expect(result.successes).toEqual([100, 300]);
+    expect(result.failures).toHaveLength(1);
+    expect(result.failures[0]?.item).toBe(2);
+    expect(result.failures[0]?.error.message).toBe("item 2 is poison");
+  });
+
+  it("collects every item as a failure when batch + every retry throws", async () => {
+    const items = ["a", "b"];
+    const fn = vi.fn(async () => {
+      throw new Error("nothing works");
+    });
+    const result = await processBatches(items, 5, fn);
+    expect(result.successes).toEqual([]);
+    expect(result.failures).toHaveLength(2);
+    expect(result.failures.map((f) => f.item)).toEqual(["a", "b"]);
+    expect(result.failures.every((f) => f.error.message === "nothing works")).toBe(true);
+  });
+
+  it("preserves the order of successes across multiple batches", async () => {
+    const items = [10, 20, 30, 40];
+    const fn = vi.fn(async (batch: number[]) => batch.map((n) => `#${n}`));
+    const result = await processBatches(items, 2, fn);
+    expect(result.successes).toEqual(["#10", "#20", "#30", "#40"]);
+  });
+});

--- a/src/batch.ts
+++ b/src/batch.ts
@@ -1,0 +1,51 @@
+/**
+ * Generic batch processor used by `batch_modify_emails` and
+ * `batch_delete_emails`. Extracted from the legacy
+ * `CallToolRequestSchema` switch in `src/index.ts` so the same code
+ * path can be exercised by unit tests without spinning the whole MCP
+ * dispatcher.
+ *
+ * Strategy: try each batch as a single concurrent group; if it throws,
+ * fall back to processing each item individually so a single failure
+ * does not poison the whole batch's results.
+ */
+
+export interface BatchOutcome<T, U> {
+  successes: U[];
+  failures: { item: T; error: Error }[];
+}
+
+/**
+ * Process `items` in chunks of `batchSize`. Each chunk is passed to
+ * `processFn` as a whole. If a chunk fails, every item in it is
+ * retried individually.
+ */
+export async function processBatches<T, U>(
+  items: T[],
+  batchSize: number,
+  processFn: (batch: T[]) => Promise<U[]>,
+): Promise<BatchOutcome<T, U>> {
+  const successes: U[] = [];
+  const failures: { item: T; error: Error }[] = [];
+
+  for (let i = 0; i < items.length; i += batchSize) {
+    const batch = items.slice(i, i + batchSize);
+    try {
+      const results = await processFn(batch);
+      successes.push(...results);
+    } catch {
+      // If the whole batch fails, retry each item individually so a
+      // single bad item does not lose the rest of the batch's results.
+      for (const item of batch) {
+        try {
+          const result = await processFn([item]);
+          successes.push(...result);
+        } catch (itemError) {
+          failures.push({ item, error: itemError as Error });
+        }
+      }
+    }
+  }
+
+  return { successes, failures };
+}

--- a/src/download-email.test.ts
+++ b/src/download-email.test.ts
@@ -240,12 +240,16 @@ describe("DownloadEmailSchema", () => {
 // 4. extractHeaders refactor verification
 // ─────────────────────────────────────────────
 describe("extractHeaders refactor - source verification", () => {
+  // `extractHeaders` was moved from src/index.ts into src/gmail-headers.ts
+  // as part of the v1.0.0 migration (see V1_MIGRATION_PLAN.md PR #1) so
+  // it could be unit-tested without exercising the dispatcher.
+  const headersSource = fs.readFileSync(path.join(__dirname, "gmail-headers.ts"), "utf-8");
   const indexSource = fs.readFileSync(path.join(__dirname, "index.ts"), "utf-8");
 
   it("extractHeaders function exists and returns rfcMessageId", () => {
-    expect(indexSource).toContain("function extractHeaders");
-    expect(indexSource).toContain("rfcMessageId");
-    expect(indexSource).toContain('getHeader("message-id")');
+    expect(headersSource).toContain("function extractHeaders");
+    expect(headersSource).toContain("rfcMessageId");
+    expect(headersSource).toContain('getHeader("message-id")');
   });
 
   it("read_email uses extractHeaders (not inline header extraction)", () => {

--- a/src/email-send.test.ts
+++ b/src/email-send.test.ts
@@ -235,4 +235,16 @@ describe("sendOrDraftEmail — error propagation", () => {
       sendOrDraftEmail(client, "send", baseArgs({ from: "me@example.com" })),
     ).rejects.toThrow(/upstream 500/);
   });
+
+  it("propagates a gmail.users.drafts.create failure for the draft action", async () => {
+    // Symmetric coverage to the send-action test above — pin that the
+    // draft branch surfaces upstream failures the same way send does
+    // (no swallowing, no rewrap into a generic error). CR finding on
+    // PR #83.
+    const boom = new Error("draft-create 500");
+    const { client } = mockGmail({ draftThrows: boom });
+    await expect(
+      sendOrDraftEmail(client, "draft", baseArgs({ from: "me@example.com" })),
+    ).rejects.toThrow(/draft-create 500/);
+  });
 });

--- a/src/email-send.test.ts
+++ b/src/email-send.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { gmail_v1 } from "googleapis";
+import { sendOrDraftEmail, type EmailSendArgs } from "./email-send.js";
+import { _resetDefaultSenderCache } from "./sender-resolver.js";
+
+// Build a mocked gmail client. Each method records its calls; any
+// method not configured to throw returns the supplied response (or a
+// minimal stub if none is supplied). The resulting object is cast to
+// `gmail_v1.Gmail` so the function-under-test sees the exact shape it
+// expects without us mocking every untouched property of the real type.
+function mockGmail(opts: {
+  threadGet?: {
+    messages?: Array<{ payload?: { headers?: Array<{ name: string; value: string }> } }>;
+  };
+  threadGetThrows?: boolean;
+  sendId?: string;
+  draftId?: string;
+  sendThrows?: Error;
+  draftThrows?: Error;
+}): {
+  client: gmail_v1.Gmail;
+  calls: {
+    threadGet: Array<unknown>;
+    messageSend: Array<unknown>;
+    draftCreate: Array<unknown>;
+  };
+} {
+  const calls = {
+    threadGet: [] as Array<unknown>,
+    messageSend: [] as Array<unknown>,
+    draftCreate: [] as Array<unknown>,
+  };
+
+  const client = {
+    users: {
+      threads: {
+        get: async (params: unknown) => {
+          calls.threadGet.push(params);
+          if (opts.threadGetThrows) throw new Error("thread fetch failed");
+          return { data: { messages: opts.threadGet?.messages ?? [] } };
+        },
+      },
+      messages: {
+        send: async (params: unknown) => {
+          calls.messageSend.push(params);
+          if (opts.sendThrows) throw opts.sendThrows;
+          return { data: { id: opts.sendId ?? "msg_default" } };
+        },
+      },
+      drafts: {
+        create: async (params: unknown) => {
+          calls.draftCreate.push(params);
+          if (opts.draftThrows) throw opts.draftThrows;
+          return { data: { id: opts.draftId ?? "draft_default" } };
+        },
+      },
+      // resolveDefaultSender uses these — return enough to make the
+      // resolver pick a value without throwing.
+      settings: {
+        sendAs: {
+          list: async () => ({
+            data: { sendAs: [{ sendAsEmail: "me@example.com", isDefault: true }] },
+          }),
+        },
+      },
+      getProfile: async () => ({ data: { emailAddress: "me@example.com" } }),
+    },
+  } as unknown as gmail_v1.Gmail;
+
+  return { client, calls };
+}
+
+const baseArgs = (overrides: Partial<EmailSendArgs> = {}): EmailSendArgs => ({
+  subject: "Hello",
+  to: ["bob@example.com"],
+  body: "Hi Bob",
+  ...overrides,
+});
+
+describe("sendOrDraftEmail — no attachments path", () => {
+  beforeEach(() => {
+    _resetDefaultSenderCache();
+  });
+
+  it("send action calls gmail.users.messages.send and returns the message ID", async () => {
+    const { client, calls } = mockGmail({ sendId: "msg_xyz" });
+    const result = await sendOrDraftEmail(client, "send", baseArgs({ from: "me@example.com" }));
+
+    expect(calls.messageSend).toHaveLength(1);
+    expect(calls.draftCreate).toHaveLength(0);
+    expect(result.content[0]?.text).toContain("msg_xyz");
+    expect(result.content[0]?.text).toContain("sent successfully");
+  });
+
+  it("draft action calls gmail.users.drafts.create and returns the draft ID", async () => {
+    const { client, calls } = mockGmail({ draftId: "draft_abc" });
+    const result = await sendOrDraftEmail(client, "draft", baseArgs({ from: "me@example.com" }));
+
+    expect(calls.draftCreate).toHaveLength(1);
+    expect(calls.messageSend).toHaveLength(0);
+    expect(result.content[0]?.text).toContain("draft_abc");
+    expect(result.content[0]?.text).toContain("draft created");
+  });
+
+  it("forwards threadId to gmail.users.messages.send", async () => {
+    const { client, calls } = mockGmail({});
+    await sendOrDraftEmail(
+      client,
+      "send",
+      baseArgs({ from: "me@example.com", threadId: "thread_42", inReplyTo: "<id-42@x>" }),
+    );
+    const call = calls.messageSend[0] as { requestBody: { threadId?: string } };
+    expect(call.requestBody.threadId).toBe("thread_42");
+  });
+});
+
+// The attachments branch (`attachments.length > 0`, routes through
+// Nodemailer + messages.send/drafts.create with `raw: base64`) is not
+// covered here — it would require a temp file fixture for Nodemailer
+// to attach, and the mime-construction logic on that path is already
+// exercised through `utl.test.ts`'s `createEmailWithNodemailer`
+// coverage. The dispatcher-level integration is best validated end-to-end
+// once the McpServer factory lands (PR #2 in the v1.0.0 plan).
+
+describe("sendOrDraftEmail — thread-header auto-resolve", () => {
+  beforeEach(() => {
+    _resetDefaultSenderCache();
+  });
+
+  it("populates inReplyTo and references from the thread when threadId is set without inReplyTo", async () => {
+    const { client, calls } = mockGmail({
+      threadGet: {
+        messages: [
+          { payload: { headers: [{ name: "Message-ID", value: "<a@x>" }] } },
+          { payload: { headers: [{ name: "Message-ID", value: "<b@x>" }] } },
+        ],
+      },
+    });
+    const args = baseArgs({ from: "me@example.com", threadId: "T1" });
+    await sendOrDraftEmail(client, "send", args);
+
+    expect(calls.threadGet).toHaveLength(1);
+    expect(args.inReplyTo).toBe("<b@x>");
+    expect(args.references).toBe("<a@x> <b@x>");
+  });
+
+  it("continues without throwing when the thread fetch fails", async () => {
+    const { client, calls } = mockGmail({ threadGetThrows: true });
+    const args = baseArgs({ from: "me@example.com", threadId: "T_broken" });
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const result = await sendOrDraftEmail(client, "send", args);
+    warnSpy.mockRestore();
+
+    expect(args.inReplyTo).toBeUndefined();
+    expect(args.references).toBeUndefined();
+    expect(calls.messageSend).toHaveLength(1);
+    expect(result.content[0]?.text).toContain("sent successfully");
+  });
+
+  it("does NOT re-fetch the thread when inReplyTo is already supplied by the caller", async () => {
+    const { client, calls } = mockGmail({});
+    await sendOrDraftEmail(
+      client,
+      "send",
+      baseArgs({ from: "me@example.com", threadId: "T1", inReplyTo: "<existing@x>" }),
+    );
+    expect(calls.threadGet).toHaveLength(0);
+  });
+});
+
+describe("sendOrDraftEmail — from auto-resolution", () => {
+  beforeEach(() => {
+    _resetDefaultSenderCache();
+  });
+
+  it("resolves an empty `from` via resolveDefaultSender", async () => {
+    const { client, calls } = mockGmail({});
+    const args = baseArgs({ from: "" });
+    await sendOrDraftEmail(client, "send", args);
+    // resolveDefaultSender returns "me@example.com" via the mocked
+    // sendAs.list — the mutation is the contract we want to pin.
+    expect(args.from).toBe("me@example.com");
+    expect(calls.messageSend).toHaveLength(1);
+  });
+
+  it("does NOT call resolveDefaultSender when the caller supplies `from`", async () => {
+    const { client, calls } = mockGmail({});
+    const args = baseArgs({ from: "explicit@example.com" });
+    await sendOrDraftEmail(client, "send", args);
+    expect(args.from).toBe("explicit@example.com");
+    expect(calls.messageSend).toHaveLength(1);
+  });
+});
+
+describe("sendOrDraftEmail — error propagation", () => {
+  beforeEach(() => {
+    _resetDefaultSenderCache();
+  });
+
+  it("propagates a gmail.users.messages.send failure", async () => {
+    const boom = new Error("upstream 500");
+    const { client } = mockGmail({ sendThrows: boom });
+    await expect(
+      sendOrDraftEmail(client, "send", baseArgs({ from: "me@example.com" })),
+    ).rejects.toThrow(/upstream 500/);
+  });
+});

--- a/src/email-send.test.ts
+++ b/src/email-send.test.ts
@@ -23,12 +23,22 @@ function mockGmail(opts: {
     threadGet: Array<unknown>;
     messageSend: Array<unknown>;
     draftCreate: Array<unknown>;
+    sendAsList: Array<unknown>;
+    getProfile: Array<unknown>;
   };
 } {
   const calls = {
     threadGet: [] as Array<unknown>,
     messageSend: [] as Array<unknown>,
     draftCreate: [] as Array<unknown>,
+    // The resolver-path methods are tracked too so a test can pin
+    // "we did NOT call resolveDefaultSender" by asserting both
+    // sendAs.list and getProfile counters stayed at zero — without
+    // these we could only check the indirect mutation of `args.from`,
+    // which leaves a hole if the resolver fired but happened to
+    // produce the same value the caller had set.
+    sendAsList: [] as Array<unknown>,
+    getProfile: [] as Array<unknown>,
   };
 
   const client = {
@@ -58,12 +68,18 @@ function mockGmail(opts: {
       // resolver pick a value without throwing.
       settings: {
         sendAs: {
-          list: async () => ({
-            data: { sendAs: [{ sendAsEmail: "me@example.com", isDefault: true }] },
-          }),
+          list: async (params: unknown) => {
+            calls.sendAsList.push(params);
+            return {
+              data: { sendAs: [{ sendAsEmail: "me@example.com", isDefault: true }] },
+            };
+          },
         },
       },
-      getProfile: async () => ({ data: { emailAddress: "me@example.com" } }),
+      getProfile: async (params: unknown) => {
+        calls.getProfile.push(params);
+        return { data: { emailAddress: "me@example.com" } };
+      },
     },
   } as unknown as gmail_v1.Gmail;
 
@@ -149,13 +165,19 @@ describe("sendOrDraftEmail — thread-header auto-resolve", () => {
     const args = baseArgs({ from: "me@example.com", threadId: "T_broken" });
 
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    const result = await sendOrDraftEmail(client, "send", args);
-    warnSpy.mockRestore();
+    try {
+      const result = await sendOrDraftEmail(client, "send", args);
 
-    expect(args.inReplyTo).toBeUndefined();
-    expect(args.references).toBeUndefined();
-    expect(calls.messageSend).toHaveLength(1);
-    expect(result.content[0]?.text).toContain("sent successfully");
+      expect(args.inReplyTo).toBeUndefined();
+      expect(args.references).toBeUndefined();
+      expect(calls.messageSend).toHaveLength(1);
+      expect(result.content[0]?.text).toContain("sent successfully");
+    } finally {
+      // Always restore the spy — without `finally`, an unexpected
+      // throw or assertion failure inside the `try` would leak the
+      // mocked `console.warn` into every subsequent test in this run.
+      warnSpy.mockRestore();
+    }
   });
 
   it("does NOT re-fetch the thread when inReplyTo is already supplied by the caller", async () => {
@@ -190,6 +212,14 @@ describe("sendOrDraftEmail — from auto-resolution", () => {
     await sendOrDraftEmail(client, "send", args);
     expect(args.from).toBe("explicit@example.com");
     expect(calls.messageSend).toHaveLength(1);
+    // Pin the contract directly: if `from` is supplied, the resolver
+    // path is fully short-circuited — neither `sendAs.list` nor
+    // `getProfile` (the two API calls inside `resolveDefaultSender`)
+    // is invoked. Without this, the test would still pass even if the
+    // resolver fired and happened to produce the same value the
+    // caller had set, hiding a wasted round-trip on every send.
+    expect(calls.sendAsList).toHaveLength(0);
+    expect(calls.getProfile).toHaveLength(0);
   });
 });
 

--- a/src/email-send.ts
+++ b/src/email-send.ts
@@ -1,0 +1,244 @@
+/**
+ * Send-or-draft pipeline for `send_email`, `draft_email`, and `reply_all`.
+ *
+ * Extracted from the legacy `CallToolRequestSchema` switch in
+ * `src/index.ts` so the same code path can be exercised by unit tests
+ * without spinning the whole MCP dispatcher (which calls main() on
+ * module load and depends on environment-driven OAuth state).
+ *
+ * Three call sites consume `sendOrDraftEmail`:
+ *   - `send_email` tool    → action: "send"
+ *   - `draft_email` tool   → action: "draft"
+ *   - `reply_all` tool     → action: "send" (after rebuilding To/Cc and
+ *                            attaching In-Reply-To / References)
+ *
+ * The `gmail` client is passed in (rather than closed over) so the
+ * function is reusable across multiple OAuth identities and trivially
+ * mockable in tests.
+ */
+
+import type { gmail_v1 } from "googleapis";
+import { ValidatedEmailArgs, createEmailMessage, createEmailWithNodemailer } from "./utl.js";
+import { resolveDefaultSender } from "./sender-resolver.js";
+import { requirePairedRecipients } from "./recipient-pairing.js";
+import { asGmailApiError } from "./gmail-errors.js";
+
+export type EmailAction = "send" | "draft";
+
+export interface EmailSendArgs extends ValidatedEmailArgs {
+  threadId?: string;
+  inReplyTo?: string;
+}
+
+export interface EmailSendResult {
+  content: Array<{ type: "text"; text: string }>;
+}
+
+/**
+ * Send a Gmail message or save it as a draft.
+ *
+ * Mutates `validatedArgs` in place when:
+ *   - `from` is empty/missing → resolved via `resolveDefaultSender(gmail)`
+ *   - `threadId` is set but `inReplyTo` is not → both `inReplyTo` and
+ *     `references` are populated from the thread's existing messages
+ *
+ * Throws on:
+ *   - recipient-pairing gate violation (when `GMAIL_MCP_RECIPIENT_PAIRING=true`
+ *     and any To/Cc/Bcc address is not in `~/.gmail-mcp/paired.json`)
+ *   - any Gmail API error from `messages.send` / `drafts.create`
+ *
+ * Thread-header resolution failures are logged to stderr and the send
+ * continues without `In-Reply-To` / `References` (degraded but not broken).
+ */
+export async function sendOrDraftEmail(
+  gmail: gmail_v1.Gmail,
+  action: EmailAction,
+  validatedArgs: EmailSendArgs,
+): Promise<EmailSendResult> {
+  let message: string;
+
+  try {
+    // Recipient pairing gate — no-op unless
+    // GMAIL_MCP_RECIPIENT_PAIRING=true. When enabled, every
+    // To/Cc/Bcc address must appear in ~/.gmail-mcp/paired.json
+    // (manage via the `pair_recipient` tool). Caps the blast
+    // radius of a prompt-injection-driven send.
+    requirePairedRecipients([
+      ...(validatedArgs.to ?? []),
+      ...(validatedArgs.cc ?? []),
+      ...(validatedArgs.bcc ?? []),
+    ]);
+
+    // Resolve `from` from the user's default send-as alias (with
+    // displayName) when the caller didn't specify one. Using the
+    // literal "me" works for the envelope but renders a bare
+    // email address in the recipient's `From:` header — see
+    // GongRzhe/Gmail-MCP-Server#77. Scope-degraded: on
+    // `gmail.send`-only tokens the sendAs/getProfile calls fail
+    // and we fall back to "me" (original behaviour).
+    if (!validatedArgs.from || validatedArgs.from.trim() === "") {
+      validatedArgs.from = await resolveDefaultSender(gmail);
+    }
+
+    // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
+    if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
+      try {
+        const threadResponse = await gmail.users.threads.get({
+          userId: "me",
+          id: validatedArgs.threadId,
+          format: "metadata",
+          metadataHeaders: ["Message-ID"],
+        });
+
+        const threadMessages = threadResponse.data.messages || [];
+        if (threadMessages.length > 0) {
+          // Collect all Message-ID values for the References chain
+          const allMessageIds: string[] = [];
+          for (const msg of threadMessages) {
+            const msgHeaders = msg.payload?.headers || [];
+            const messageIdHeader = msgHeaders.find((h) => h.name?.toLowerCase() === "message-id");
+            if (messageIdHeader?.value) {
+              allMessageIds.push(messageIdHeader.value);
+            }
+          }
+
+          // Last message's Message-ID becomes In-Reply-To.
+          // threadMessages.length > 0 is guaranteed by the outer if;
+          // the `?.` keeps the compiler happy under noUncheckedIndexedAccess.
+          const lastMessage = threadMessages[threadMessages.length - 1];
+          const lastHeaders = lastMessage?.payload?.headers || [];
+          const lastMessageId = lastHeaders.find(
+            (h) => h.name?.toLowerCase() === "message-id",
+          )?.value;
+
+          if (lastMessageId) {
+            validatedArgs.inReplyTo = lastMessageId;
+          }
+          if (allMessageIds.length > 0) {
+            validatedArgs.references = allMessageIds.join(" ");
+          }
+        }
+      } catch (threadError: unknown) {
+        const msg = threadError instanceof Error ? threadError.message : String(threadError);
+        console.warn(
+          `Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${msg}`,
+        );
+        // Continue without threading headers - degraded but not broken
+      }
+    }
+
+    // Check if we have attachments
+    if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
+      // Use Nodemailer to create properly formatted RFC822 message
+      message = await createEmailWithNodemailer(validatedArgs);
+
+      const encodedMessage = Buffer.from(message)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+      if (action === "send") {
+        const result = await gmail.users.messages.send({
+          userId: "me",
+          requestBody: {
+            raw: encodedMessage,
+            ...(validatedArgs.threadId && { threadId: validatedArgs.threadId }),
+          },
+        });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Email sent successfully with ID: ${result.data.id}`,
+            },
+          ],
+        };
+      } else {
+        const messageRequest = {
+          raw: encodedMessage,
+          ...(validatedArgs.threadId && { threadId: validatedArgs.threadId }),
+        };
+
+        const response = await gmail.users.drafts.create({
+          userId: "me",
+          requestBody: {
+            message: messageRequest,
+          },
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Email draft created successfully with ID: ${response.data.id}`,
+            },
+          ],
+        };
+      }
+    } else {
+      // For emails without attachments, use the existing simple method
+      message = createEmailMessage(validatedArgs);
+
+      const encodedMessage = Buffer.from(message)
+        .toString("base64")
+        .replace(/\+/g, "-")
+        .replace(/\//g, "_")
+        .replace(/=+$/, "");
+
+      interface GmailMessageRequest {
+        raw: string;
+        threadId?: string;
+      }
+
+      const messageRequest: GmailMessageRequest = {
+        raw: encodedMessage,
+      };
+
+      if (validatedArgs.threadId) {
+        messageRequest.threadId = validatedArgs.threadId;
+      }
+
+      if (action === "send") {
+        const response = await gmail.users.messages.send({
+          userId: "me",
+          requestBody: messageRequest,
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Email sent successfully with ID: ${response.data.id}`,
+            },
+          ],
+        };
+      } else {
+        const response = await gmail.users.drafts.create({
+          userId: "me",
+          requestBody: {
+            message: messageRequest,
+          },
+        });
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Email draft created successfully with ID: ${response.data.id}`,
+            },
+          ],
+        };
+      }
+    }
+  } catch (error: unknown) {
+    // Log attachment-related errors for debugging
+    if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
+      const { code, message } = asGmailApiError(error);
+      const codeTag = code !== undefined ? ` (HTTP ${code})` : "";
+      console.error(
+        `Failed to send email with ${validatedArgs.attachments.length} attachments${codeTag}:`,
+        message,
+      );
+    }
+    throw error;
+  }
+}

--- a/src/gmail-headers.test.ts
+++ b/src/gmail-headers.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from "vitest";
+import type { gmail_v1 } from "googleapis";
+import { makeHeaderGetter, extractHeaders } from "./gmail-headers.js";
+
+const headers = (pairs: Array<[string, string]>): gmail_v1.Schema$MessagePartHeader[] =>
+  pairs.map(([name, value]) => ({ name, value }));
+
+describe("makeHeaderGetter", () => {
+  it("returns the value for a header by exact-case name", () => {
+    const get = makeHeaderGetter(headers([["Subject", "hello"]]));
+    expect(get("Subject")).toBe("hello");
+  });
+
+  it("matches case-insensitively (Gmail varies between 'From' and 'from')", () => {
+    const get = makeHeaderGetter(headers([["From", "alice@example.com"]]));
+    expect(get("from")).toBe("alice@example.com");
+    expect(get("FROM")).toBe("alice@example.com");
+    expect(get("From")).toBe("alice@example.com");
+  });
+
+  it("returns the empty string for a missing header", () => {
+    const get = makeHeaderGetter(headers([["From", "alice@example.com"]]));
+    expect(get("Subject")).toBe("");
+  });
+
+  it("returns the empty string when the headers array is undefined", () => {
+    const get = makeHeaderGetter(undefined);
+    expect(get("From")).toBe("");
+    expect(get("anything")).toBe("");
+  });
+
+  it("handles a header whose value is missing or empty", () => {
+    const get = makeHeaderGetter([{ name: "X-Bizarre" }]);
+    expect(get("X-Bizarre")).toBe("");
+  });
+});
+
+describe("extractHeaders", () => {
+  it("returns the canonical 5-field shape from a fully-populated payload", () => {
+    const payload: gmail_v1.Schema$MessagePart = {
+      headers: headers([
+        ["Subject", "Re: project update"],
+        ["From", "Alice <alice@example.com>"],
+        ["To", "bob@example.com"],
+        ["Date", "Mon, 25 Apr 2026 10:00:00 +0000"],
+        ["Message-ID", "<abc-123@mail.example.com>"],
+      ]),
+    };
+    expect(extractHeaders(payload)).toEqual({
+      subject: "Re: project update",
+      from: "Alice <alice@example.com>",
+      to: "bob@example.com",
+      date: "Mon, 25 Apr 2026 10:00:00 +0000",
+      rfcMessageId: "<abc-123@mail.example.com>",
+    });
+  });
+
+  it("substitutes empty strings for missing headers (no null leak)", () => {
+    const payload: gmail_v1.Schema$MessagePart = {
+      headers: headers([["Subject", "only subject"]]),
+    };
+    expect(extractHeaders(payload)).toEqual({
+      subject: "only subject",
+      from: "",
+      to: "",
+      date: "",
+      rfcMessageId: "",
+    });
+  });
+
+  it("returns five empty strings when the payload is undefined", () => {
+    expect(extractHeaders(undefined)).toEqual({
+      subject: "",
+      from: "",
+      to: "",
+      date: "",
+      rfcMessageId: "",
+    });
+  });
+
+  it("matches Message-ID case-insensitively (gmail returns 'Message-Id' some days, 'Message-ID' others)", () => {
+    const lower: gmail_v1.Schema$MessagePart = {
+      headers: headers([["message-id", "<lower@x>"]]),
+    };
+    const mixed: gmail_v1.Schema$MessagePart = {
+      headers: headers([["Message-Id", "<mixed@x>"]]),
+    };
+    const upper: gmail_v1.Schema$MessagePart = {
+      headers: headers([["MESSAGE-ID", "<upper@x>"]]),
+    };
+    expect(extractHeaders(lower).rfcMessageId).toBe("<lower@x>");
+    expect(extractHeaders(mixed).rfcMessageId).toBe("<mixed@x>");
+    expect(extractHeaders(upper).rfcMessageId).toBe("<upper@x>");
+  });
+});

--- a/src/gmail-headers.ts
+++ b/src/gmail-headers.ts
@@ -37,3 +37,29 @@ export function makeHeaderGetter(
 ): (name: string) => string {
   return (name) => headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
 }
+
+/**
+ * Extract the canonical set of headers (`subject`, `from`, `to`, `date`,
+ * `rfcMessageId`) from a Gmail message payload. Used by `read_email`,
+ * `download_email`, and the thread-listing tools to build the
+ * single-line summary block at the top of each rendered message.
+ *
+ * Returns empty strings for any missing header so callers can format
+ * unconditionally without null checks.
+ */
+export function extractHeaders(payload: gmail_v1.Schema$MessagePart | undefined): {
+  subject: string;
+  from: string;
+  to: string;
+  date: string;
+  rfcMessageId: string;
+} {
+  const getHeader = makeHeaderGetter(payload?.headers);
+  return {
+    subject: getHeader("subject"),
+    from: getHeader("from"),
+    to: getHeader("to"),
+    date: getHeader("date"),
+    rfcMessageId: getHeader("message-id"),
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,8 +17,6 @@ import http from "http";
 import open from "open";
 import os from "os";
 import {
-  createEmailMessage,
-  createEmailWithNodemailer,
   resolveDownloadSavePath,
   getDownloadDir,
   safeWriteFile,
@@ -26,7 +24,6 @@ import {
   pickBody,
   pickBodyAnnotated,
   HTML_FALLBACK_NOTE,
-  ValidatedEmailArgs,
 } from "./utl.js";
 import {
   createLabel,
@@ -85,13 +82,14 @@ import {
   PairRecipientSchema,
 } from "./tools.js";
 import { gmailMessageToJson, emailToTxt, emailToHtml } from "./email-export.js";
-import { makeHeaderGetter } from "./gmail-headers.js";
+import { extractHeaders } from "./gmail-headers.js";
 import { logAudit } from "./audit-log.js";
+import { sendOrDraftEmail } from "./email-send.js";
+import { processBatches } from "./batch.js";
 import { listPrompts, getPrompt } from "./prompts.js";
 import { wrapToolHandler } from "./middleware.js";
 import { sanitizeForLlm } from "./sanitize.js";
 import { asGmailApiError, buildInvalidGrantPayload, isInvalidGrantError } from "./gmail-errors.js";
-import { resolveDefaultSender } from "./sender-resolver.js";
 import {
   addPairedAddress,
   readPairedList,
@@ -136,26 +134,8 @@ let authorizedScopes: string[] = DEFAULT_SCOPES;
 // `resolveDefaultSender` + its cache live in their own module so they
 // can be unit-tested without exercising the 1300-line dispatcher
 // below. See src/sender-resolver.ts for the fallback chain (GongRzhe#77).
-
-/**
- * Extract common headers from Gmail message payload
- */
-function extractHeaders(payload: GmailMessagePart | undefined): {
-  subject: string;
-  from: string;
-  to: string;
-  date: string;
-  rfcMessageId: string;
-} {
-  const getHeader = makeHeaderGetter(payload?.headers);
-  return {
-    subject: getHeader("subject"),
-    from: getHeader("from"),
-    to: getHeader("to"),
-    date: getHeader("date"),
-    rfcMessageId: getHeader("message-id"),
-  };
-}
+// `extractHeaders` lives in src/gmail-headers.ts next to its sibling
+// `makeHeaderGetter`.
 
 function loadCredentials() {
   try {
@@ -604,240 +584,11 @@ async function main() {
     // handler runs, maps RateLimitError → isError payload with the
     // mcp_safeguard error-type, and logs audit in a `finally` with one
     // of three states: "ok" | "error" | "rate_limited".
-
-    async function handleEmailAction(
-      action: "send" | "draft",
-      validatedArgs: ValidatedEmailArgs & { threadId?: string; inReplyTo?: string },
-    ) {
-      let message: string;
-
-      try {
-        // Recipient pairing gate — no-op unless
-        // GMAIL_MCP_RECIPIENT_PAIRING=true. When enabled, every
-        // To/Cc/Bcc address must appear in ~/.gmail-mcp/paired.json
-        // (manage via the `pair_recipient` tool). Caps the blast
-        // radius of a prompt-injection-driven send.
-        requirePairedRecipients([
-          ...(validatedArgs.to ?? []),
-          ...(validatedArgs.cc ?? []),
-          ...(validatedArgs.bcc ?? []),
-        ]);
-
-        // Resolve `from` from the user's default send-as alias (with
-        // displayName) when the caller didn't specify one. Using the
-        // literal "me" works for the envelope but renders a bare
-        // email address in the recipient's `From:` header — see
-        // GongRzhe/Gmail-MCP-Server#77. Scope-degraded: on
-        // `gmail.send`-only tokens the sendAs/getProfile calls fail
-        // and we fall back to "me" (original behaviour).
-        if (!validatedArgs.from || validatedArgs.from.trim() === "") {
-          validatedArgs.from = await resolveDefaultSender(gmail);
-        }
-
-        // Auto-resolve threading headers when threadId is provided but inReplyTo is missing
-        if (validatedArgs.threadId && !validatedArgs.inReplyTo) {
-          try {
-            const threadResponse = await gmail.users.threads.get({
-              userId: "me",
-              id: validatedArgs.threadId,
-              format: "metadata",
-              metadataHeaders: ["Message-ID"],
-            });
-
-            const threadMessages = threadResponse.data.messages || [];
-            if (threadMessages.length > 0) {
-              // Collect all Message-ID values for the References chain
-              const allMessageIds: string[] = [];
-              for (const msg of threadMessages) {
-                const msgHeaders = msg.payload?.headers || [];
-                const messageIdHeader = msgHeaders.find(
-                  (h) => h.name?.toLowerCase() === "message-id",
-                );
-                if (messageIdHeader?.value) {
-                  allMessageIds.push(messageIdHeader.value);
-                }
-              }
-
-              // Last message's Message-ID becomes In-Reply-To.
-              // threadMessages.length > 0 is guaranteed by the outer if;
-              // the `?.` keeps the compiler happy under noUncheckedIndexedAccess.
-              const lastMessage = threadMessages[threadMessages.length - 1];
-              const lastHeaders = lastMessage?.payload?.headers || [];
-              const lastMessageId = lastHeaders.find(
-                (h) => h.name?.toLowerCase() === "message-id",
-              )?.value;
-
-              if (lastMessageId) {
-                validatedArgs.inReplyTo = lastMessageId;
-              }
-              if (allMessageIds.length > 0) {
-                validatedArgs.references = allMessageIds.join(" ");
-              }
-            }
-          } catch (threadError: unknown) {
-            const msg = threadError instanceof Error ? threadError.message : String(threadError);
-            console.warn(
-              `Warning: Could not fetch thread ${validatedArgs.threadId} for header resolution: ${msg}`,
-            );
-            // Continue without threading headers - degraded but not broken
-          }
-        }
-
-        // Check if we have attachments
-        if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
-          // Use Nodemailer to create properly formatted RFC822 message
-          message = await createEmailWithNodemailer(validatedArgs);
-
-          if (action === "send") {
-            const encodedMessage = Buffer.from(message)
-              .toString("base64")
-              .replace(/\+/g, "-")
-              .replace(/\//g, "_")
-              .replace(/=+$/, "");
-
-            const result = await gmail.users.messages.send({
-              userId: "me",
-              requestBody: {
-                raw: encodedMessage,
-                ...(validatedArgs.threadId && { threadId: validatedArgs.threadId }),
-              },
-            });
-
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Email sent successfully with ID: ${result.data.id}`,
-                },
-              ],
-            };
-          } else {
-            // For drafts with attachments, use the raw message
-            const encodedMessage = Buffer.from(message)
-              .toString("base64")
-              .replace(/\+/g, "-")
-              .replace(/\//g, "_")
-              .replace(/=+$/, "");
-
-            const messageRequest = {
-              raw: encodedMessage,
-              ...(validatedArgs.threadId && { threadId: validatedArgs.threadId }),
-            };
-
-            const response = await gmail.users.drafts.create({
-              userId: "me",
-              requestBody: {
-                message: messageRequest,
-              },
-            });
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Email draft created successfully with ID: ${response.data.id}`,
-                },
-              ],
-            };
-          }
-        } else {
-          // For emails without attachments, use the existing simple method
-          message = createEmailMessage(validatedArgs);
-
-          const encodedMessage = Buffer.from(message)
-            .toString("base64")
-            .replace(/\+/g, "-")
-            .replace(/\//g, "_")
-            .replace(/=+$/, "");
-
-          // Define the type for messageRequest
-          interface GmailMessageRequest {
-            raw: string;
-            threadId?: string;
-          }
-
-          const messageRequest: GmailMessageRequest = {
-            raw: encodedMessage,
-          };
-
-          // Add threadId if specified
-          if (validatedArgs.threadId) {
-            messageRequest.threadId = validatedArgs.threadId;
-          }
-
-          if (action === "send") {
-            const response = await gmail.users.messages.send({
-              userId: "me",
-              requestBody: messageRequest,
-            });
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Email sent successfully with ID: ${response.data.id}`,
-                },
-              ],
-            };
-          } else {
-            const response = await gmail.users.drafts.create({
-              userId: "me",
-              requestBody: {
-                message: messageRequest,
-              },
-            });
-            return {
-              content: [
-                {
-                  type: "text",
-                  text: `Email draft created successfully with ID: ${response.data.id}`,
-                },
-              ],
-            };
-          }
-        }
-      } catch (error: unknown) {
-        // Log attachment-related errors for debugging
-        if (validatedArgs.attachments && validatedArgs.attachments.length > 0) {
-          const { code, message } = asGmailApiError(error);
-          const codeTag = code !== undefined ? ` (HTTP ${code})` : "";
-          console.error(
-            `Failed to send email with ${validatedArgs.attachments.length} attachments${codeTag}:`,
-            message,
-          );
-        }
-        throw error;
-      }
-    }
-
-    // Helper function to process operations in batches
-    async function processBatches<T, U>(
-      items: T[],
-      batchSize: number,
-      processFn: (batch: T[]) => Promise<U[]>,
-    ): Promise<{ successes: U[]; failures: { item: T; error: Error }[] }> {
-      const successes: U[] = [];
-      const failures: { item: T; error: Error }[] = [];
-
-      // Process in batches
-      for (let i = 0; i < items.length; i += batchSize) {
-        const batch = items.slice(i, i + batchSize);
-        try {
-          const results = await processFn(batch);
-          successes.push(...results);
-        } catch {
-          // If batch fails, try individual items
-          for (const item of batch) {
-            try {
-              const result = await processFn([item]);
-              successes.push(...result);
-            } catch (itemError) {
-              failures.push({ item, error: itemError as Error });
-            }
-          }
-        }
-      }
-
-      return { successes, failures };
-    }
+    //
+    // The send-or-draft pipeline lives in `src/email-send.ts`
+    // (`sendOrDraftEmail`) and the batch processor in `src/batch.ts`
+    // (`processBatches`) — both extracted so they can be unit-tested
+    // without spinning up the dispatcher.
 
     try {
       return await wrapToolHandler(name, args, async () => {
@@ -846,7 +597,7 @@ async function main() {
           case "draft_email": {
             const validatedArgs = SendEmailSchema.parse(args);
             const action = name === "send_email" ? "send" : "draft";
-            return await handleEmailAction(action, validatedArgs);
+            return await sendOrDraftEmail(gmail, action, validatedArgs);
           }
 
           case "pair_recipient": {
@@ -2015,7 +1766,7 @@ async function main() {
             // Build References header (original References + original Message-ID)
             const references = buildReferencesHeader(originalReferences, originalMessageId);
 
-            // Prepare the email arguments for handleEmailAction
+            // Prepare the email arguments for sendOrDraftEmail
             const emailArgs = {
               to: replyTo,
               cc: replyCc.length > 0 ? replyCc : undefined,
@@ -2029,8 +1780,8 @@ async function main() {
               attachments: validatedArgs.attachments,
             };
 
-            // Use the existing handleEmailAction to send the reply
-            await handleEmailAction("send", emailArgs);
+            // Use the shared sendOrDraftEmail to send the reply
+            await sendOrDraftEmail(gmail, "send", emailArgs);
 
             // Enhance the response with reply-all specific info
             return {

--- a/src/utl.test.ts
+++ b/src/utl.test.ts
@@ -88,8 +88,11 @@ describe("Source verification", () => {
     );
   });
 
-  it("handleEmailAction auto-resolves threading headers", () => {
-    const source = fs.readFileSync(path.join(srcDir, "index.ts"), "utf-8");
+  it("sendOrDraftEmail auto-resolves threading headers", () => {
+    // The thread-header auto-resolve logic was extracted from
+    // src/index.ts into src/email-send.ts as part of the v1.0.0
+    // migration (see V1_MIGRATION_PLAN.md PR #1).
+    const source = fs.readFileSync(path.join(srcDir, "email-send.ts"), "utf-8");
     expect(source).toContain("validatedArgs.threadId && !validatedArgs.inReplyTo");
     expect(source).toContain("gmail.users.threads.get");
     expect(source).toContain("validatedArgs.inReplyTo = lastMessageId");


### PR DESCRIPTION
## Why

Foundation step toward `v1.0.0` (`McpServer` + `defineTool()` migration). Three previously-untestable helpers move out of the 1300-line `CallToolRequestSchema` switch closure in `src/index.ts` into their own modules so they can be unit-tested directly. No behaviour change. No new dependency.

This is **PR #1 of 7** in the migration. The plan exists locally as a working doc (not committed); each subsequent PR is a self-contained step that leaves \`main\` working.

## What moved

| From `src/index.ts` (LOC) | To | Notes |
|---|---|---|
| `handleEmailAction` (~200) | `src/email-send.ts` → `sendOrDraftEmail(gmail, action, args)` | `gmail` is now an explicit param; trivially mockable |
| `processBatches` (~28) | `src/batch.ts` | Pure generic helper, no Gmail dep |
| `extractHeaders` (~16) | `src/gmail-headers.ts` | Co-located with `makeHeaderGetter` |

## Call sites updated

- `case \"send_email\"` / `case \"draft_email\"` → `sendOrDraftEmail`
- `case \"reply_all\"` → `sendOrDraftEmail` for the actual send
- `read_email`, `download_email` → imported `extractHeaders`

## Tests

| File | New tests | Covers |
|---|---|---|
| `src/email-send.test.ts` | 10 | send / draft happy paths, threadId forwarding, thread-header auto-resolve (success + failure + short-circuit), `from` auto-resolution, error propagation |
| `src/batch.test.ts` | 6 | empty input, single happy batch, batch-size respected, per-item retry on batch failure, all-fail collection, ordering preservation |
| `src/gmail-headers.test.ts` | 9 | `makeHeaderGetter` case-insensitive matching + undefined fallback; `extractHeaders` 5-field shape + missing-header substitution + Message-ID case variations |

Two existing source-grep tests redirected (the strings they grep moved with the code):
- \`src/utl.test.ts\` → now greps \`src/email-send.ts\`
- \`src/download-email.test.ts\` → now greps \`src/gmail-headers.ts\`

**Total: 440 → 464 (+24).** Coverage: ~39% → ~60%.

## Behaviour preserved

- Tool surface unchanged (26 tools, same names, same schemas, same outputs)
- Error shape unchanged (same MCP \`isError\` payloads)
- Audit-log states unchanged (\`ok\` / \`error\` / \`rate_limited\`)
- Rate-limit semantics unchanged (still inside \`wrapToolHandler\`)
- Recipient-pairing gate still fires from inside \`sendOrDraftEmail\` for send/draft/reply_all (and from the dispatcher for \`create_filter.action.forward\`, unchanged)

## Checklist

- [x] Title ≤ 72 chars (69)
- [x] Tests green (\`npm test\`: 464 passed)
- [x] Lint clean (\`npm run lint\`)
- [x] Format clean (\`npm run format\`)
- [x] Build green (\`npm run build\`)
- [x] No new runtime dependency
- [x] Signed commit