### PR TITLE
feat(tools): register 4 trivial delete/modify tools via defineTool

### DIFF
--- a/src/tools/filters.ts
+++ b/src/tools/filters.ts
@@ -1,0 +1,46 @@
+/**
+ * Filter-domain tool registrars. PR #3 starts with `delete_filter`
+ * (trivial wrapper over `deleteFilter` from `src/filter-manager.ts`);
+ * PR #4 extends with `create_filter` (with the recipient-pairing
+ * forward-action gate), `list_filters`, `get_filter`, and
+ * `create_filter_from_template`. Once every filter-domain tool lives
+ * here, PR #7 deletes the corresponding switch arms from the legacy
+ * dispatcher in `src/index.ts`.
+ */
+
+import type { gmail_v1 } from "googleapis";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defineTool } from "./_shared.js";
+import { getToolByName, DeleteFilterSchema } from "../tools.js";
+import { deleteFilter } from "../filter-manager.js";
+
+function pull(name: string) {
+  const def = getToolByName(name);
+  if (!def) {
+    throw new Error(`Tool definition missing: ${name}`);
+  }
+  return { description: def.description, scopes: def.scopes, annotations: def.annotations };
+}
+
+export function registerFilterTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  authorizedScopes: readonly string[],
+): void {
+  const deleteFilterDef = pull("delete_filter");
+  defineTool(
+    server,
+    "delete_filter",
+    deleteFilterDef.description,
+    DeleteFilterSchema.shape,
+    async (args) => {
+      const result = await deleteFilter(gmail, args.filterId);
+      return {
+        content: [{ type: "text", text: result.message }],
+      };
+    },
+    deleteFilterDef.annotations,
+    deleteFilterDef.scopes,
+    authorizedScopes,
+  );
+}

--- a/src/tools/labels.ts
+++ b/src/tools/labels.ts
@@ -1,0 +1,45 @@
+/**
+ * Label-domain tool registrars. PR #3 starts with `delete_label`
+ * (trivial wrapper over `deleteLabel` from `src/label-manager.ts`);
+ * PR #4 extends with `create_label`, `update_label`,
+ * `get_or_create_label`, and `list_email_labels`. Once every
+ * label-domain tool lives here, PR #7 deletes the corresponding
+ * switch arms from the legacy dispatcher in `src/index.ts`.
+ */
+
+import type { gmail_v1 } from "googleapis";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defineTool } from "./_shared.js";
+import { getToolByName, DeleteLabelSchema } from "../tools.js";
+import { deleteLabel } from "../label-manager.js";
+
+function pull(name: string) {
+  const def = getToolByName(name);
+  if (!def) {
+    throw new Error(`Tool definition missing: ${name}`);
+  }
+  return { description: def.description, scopes: def.scopes, annotations: def.annotations };
+}
+
+export function registerLabelTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  authorizedScopes: readonly string[],
+): void {
+  const deleteLabelDef = pull("delete_label");
+  defineTool(
+    server,
+    "delete_label",
+    deleteLabelDef.description,
+    DeleteLabelSchema.shape,
+    async (args) => {
+      const result = await deleteLabel(gmail, args.id);
+      return {
+        content: [{ type: "text", text: result.message }],
+      };
+    },
+    deleteLabelDef.annotations,
+    deleteLabelDef.scopes,
+    authorizedScopes,
+  );
+}

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -1,0 +1,53 @@
+/**
+ * Message-domain tool registrars. PR #3 starts with `delete_email`
+ * (the single trivial wrapper); subsequent PRs (`#4` for label/filter
+ * management, `#5` for `read_email`/`search_emails`/`modify_email`/
+ * `batch_modify_emails`/`batch_delete_emails`, `#6` for `download_email`)
+ * extend this file. Once every message-domain tool lives here, PR #7
+ * deletes the corresponding switch arms from the legacy dispatcher in
+ * `src/index.ts` and wires `createServer` to call this registrar.
+ */
+
+import type { gmail_v1 } from "googleapis";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defineTool } from "./_shared.js";
+import { getToolByName, DeleteEmailSchema } from "../tools.js";
+
+function pull(name: string) {
+  const def = getToolByName(name);
+  if (!def) {
+    throw new Error(`Tool definition missing: ${name}`);
+  }
+  return { description: def.description, scopes: def.scopes, annotations: def.annotations };
+}
+
+export function registerMessageTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  authorizedScopes: readonly string[],
+): void {
+  const deleteEmail = pull("delete_email");
+  defineTool(
+    server,
+    "delete_email",
+    deleteEmail.description,
+    DeleteEmailSchema.shape,
+    async (args) => {
+      await gmail.users.messages.delete({
+        userId: "me",
+        id: args.messageId,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Email ${args.messageId} deleted successfully`,
+          },
+        ],
+      };
+    },
+    deleteEmail.annotations,
+    deleteEmail.scopes,
+    authorizedScopes,
+  );
+}

--- a/src/tools/registrars.test.ts
+++ b/src/tools/registrars.test.ts
@@ -1,0 +1,263 @@
+/**
+ * E2E tests for the trivial-tool registrars introduced in PR #3.
+ *
+ * Each registrar wires its tools into a real `McpServer` (built via
+ * `createServer`), connected to an `InMemoryTransport` pair. A
+ * `Client` then issues real `tools/call` requests and we assert on
+ * the parsed result. This pins the entire `Client → SDK → defineTool
+ * adapter → wrapToolHandler → handler → gmail mock` round-trip — the
+ * exact pipeline that PR #7's switchover will run in production.
+ *
+ * Note: the legacy dispatcher in `src/index.ts` is not exercised
+ * here. Until PR #7 wires `createServer` into the entry point, the
+ * production runtime still routes tool calls through that dispatcher;
+ * these tests cover the parallel `McpServer` path that PR #7 will
+ * promote to default.
+ */
+
+import { describe, it, expect } from "vitest";
+import type { gmail_v1 } from "googleapis";
+import { OAuth2Client } from "google-auth-library";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { createServer } from "../server.js";
+import { registerMessageTools } from "./messages.js";
+import { registerLabelTools } from "./labels.js";
+import { registerFilterTools } from "./filters.js";
+import { registerThreadTools } from "./threads.js";
+
+interface MockedGmailCalls {
+  messageDelete: Array<unknown>;
+  threadModify: Array<unknown>;
+  filterDelete: Array<unknown>;
+  labelDelete: Array<unknown>;
+}
+
+function mockGmail(): { client: gmail_v1.Gmail; calls: MockedGmailCalls } {
+  const calls: MockedGmailCalls = {
+    messageDelete: [],
+    threadModify: [],
+    filterDelete: [],
+    labelDelete: [],
+  };
+  const client = {
+    users: {
+      messages: {
+        delete: async (params: unknown) => {
+          calls.messageDelete.push(params);
+          return { data: {} };
+        },
+      },
+      threads: {
+        modify: async (params: unknown) => {
+          calls.threadModify.push(params);
+          return { data: {} };
+        },
+      },
+      labels: {
+        // `deleteLabel` (src/label-manager.ts) does a `get` first to
+        // refuse system-label deletion + to surface the label name in
+        // the success message. Mock returns a non-system label so the
+        // delete proceeds.
+        get: async (params: unknown) => {
+          const id = (params as { id?: string }).id ?? "Unknown";
+          return { data: { id, name: id, type: "user" } };
+        },
+        delete: async (params: unknown) => {
+          calls.labelDelete.push(params);
+          return { data: {} };
+        },
+      },
+      settings: {
+        filters: {
+          delete: async (params: unknown) => {
+            calls.filterDelete.push(params);
+            return { data: {} };
+          },
+        },
+      },
+    },
+  } as unknown as gmail_v1.Gmail;
+  return { client, calls };
+}
+
+interface ConnectedFixture {
+  client: Client;
+  calls: MockedGmailCalls;
+  close: () => Promise<void>;
+}
+
+async function buildAndConnect(scopes: string[]): Promise<ConnectedFixture> {
+  const server = createServer({
+    oauth2Client: new OAuth2Client(),
+    authorizedScopes: scopes,
+  });
+  const { client: gmail, calls } = mockGmail();
+  registerMessageTools(server, gmail, scopes);
+  registerLabelTools(server, gmail, scopes);
+  registerFilterTools(server, gmail, scopes);
+  registerThreadTools(server, gmail, scopes);
+
+  const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "pr3-test", version: "0.0.0" });
+  await Promise.all([server.connect(serverTransport), client.connect(clientTransport)]);
+  return {
+    client,
+    calls,
+    close: async () => {
+      await Promise.all([client.close(), server.close()]);
+    },
+  };
+}
+
+describe("PR #3 registrars — delete_email (mail.google.com scope)", () => {
+  it("calls gmail.users.messages.delete with the supplied messageId", async () => {
+    const fix = await buildAndConnect(["mail.google.com"]);
+    try {
+      const result = (await fix.client.callTool({
+        name: "delete_email",
+        arguments: { messageId: "msg_target_123" },
+      })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.text).toContain("msg_target_123");
+      expect(result.content[0]?.text).toContain("deleted successfully");
+      expect(fix.calls.messageDelete).toHaveLength(1);
+      expect(fix.calls.messageDelete[0]).toMatchObject({
+        userId: "me",
+        id: "msg_target_123",
+      });
+    } finally {
+      await fix.close();
+    }
+  });
+
+  it("is NOT advertised when the token only carries gmail.modify (delete needs mail.google.com)", async () => {
+    const fix = await buildAndConnect(["gmail.modify"]);
+    try {
+      const list = await fix.client.listTools();
+      expect(list.tools.find((t) => t.name === "delete_email")).toBeUndefined();
+    } finally {
+      await fix.close();
+    }
+  });
+});
+
+describe("PR #3 registrars — delete_label", () => {
+  it("calls gmail.users.labels.delete with the supplied id", async () => {
+    const fix = await buildAndConnect(["gmail.modify", "gmail.labels"]);
+    try {
+      const result = (await fix.client.callTool({
+        name: "delete_label",
+        arguments: { id: "Label_42" },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content[0]?.text).toContain("Label_42");
+      expect(fix.calls.labelDelete).toHaveLength(1);
+      expect(fix.calls.labelDelete[0]).toMatchObject({
+        userId: "me",
+        id: "Label_42",
+      });
+    } finally {
+      await fix.close();
+    }
+  });
+});
+
+describe("PR #3 registrars — delete_filter", () => {
+  it("calls gmail.users.settings.filters.delete with the supplied filterId", async () => {
+    const fix = await buildAndConnect(["gmail.settings.basic"]);
+    try {
+      const result = (await fix.client.callTool({
+        name: "delete_filter",
+        arguments: { filterId: "filter_xyz" },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content[0]?.text.length).toBeGreaterThan(0);
+      expect(fix.calls.filterDelete).toHaveLength(1);
+      expect(fix.calls.filterDelete[0]).toMatchObject({
+        userId: "me",
+        id: "filter_xyz",
+      });
+    } finally {
+      await fix.close();
+    }
+  });
+});
+
+describe("PR #3 registrars — modify_thread", () => {
+  it("forwards addLabelIds + removeLabelIds to gmail.users.threads.modify", async () => {
+    const fix = await buildAndConnect(["gmail.modify"]);
+    try {
+      const result = (await fix.client.callTool({
+        name: "modify_thread",
+        arguments: {
+          threadId: "thread_999",
+          addLabelIds: ["L_A", "L_B"],
+          removeLabelIds: ["INBOX"],
+        },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content[0]?.text).toContain("thread_999");
+      expect(fix.calls.threadModify).toHaveLength(1);
+      expect(fix.calls.threadModify[0]).toMatchObject({
+        userId: "me",
+        id: "thread_999",
+        requestBody: { addLabelIds: ["L_A", "L_B"], removeLabelIds: ["INBOX"] },
+      });
+    } finally {
+      await fix.close();
+    }
+  });
+
+  it("omits empty label arrays from the request body (no addLabelIds when not supplied)", async () => {
+    const fix = await buildAndConnect(["gmail.modify"]);
+    try {
+      await fix.client.callTool({
+        name: "modify_thread",
+        arguments: {
+          threadId: "thread_only_remove",
+          removeLabelIds: ["UNREAD"],
+        },
+      });
+      const params = fix.calls.threadModify[0] as {
+        requestBody: { addLabelIds?: string[]; removeLabelIds?: string[] };
+      };
+      expect(params.requestBody.addLabelIds).toBeUndefined();
+      expect(params.requestBody.removeLabelIds).toEqual(["UNREAD"]);
+    } finally {
+      await fix.close();
+    }
+  });
+});
+
+describe("PR #3 registrars — combined tools/list shape", () => {
+  it("advertises all four tools when the token covers every required scope", async () => {
+    const fix = await buildAndConnect([
+      "mail.google.com",
+      "gmail.modify",
+      "gmail.labels",
+      "gmail.settings.basic",
+    ]);
+    try {
+      const list = await fix.client.listTools();
+      const names = list.tools.map((t) => t.name).sort();
+      expect(names).toEqual(["delete_email", "delete_filter", "delete_label", "modify_thread"]);
+    } finally {
+      await fix.close();
+    }
+  });
+
+  it("filters out tools whose required scopes are missing from the token", async () => {
+    // Only gmail.modify + gmail.labels — covers `delete_label` and
+    // `modify_thread`, but NOT `delete_email` (needs mail.google.com)
+    // and NOT `delete_filter` (needs gmail.settings.basic). Pinning
+    // scope-aware filtering on a populated set instead of an empty
+    // one avoids the SDK quirk where `tools/list` becomes
+    // `Method not found` when 0 tools are registered.
+    const fix = await buildAndConnect(["gmail.modify", "gmail.labels"]);
+    try {
+      const list = await fix.client.listTools();
+      const names = list.tools.map((t) => t.name).sort();
+      expect(names).toEqual(["delete_label", "modify_thread"]);
+    } finally {
+      await fix.close();
+    }
+  });
+});

--- a/src/tools/threads.ts
+++ b/src/tools/threads.ts
@@ -1,0 +1,60 @@
+/**
+ * Thread-domain tool registrars. PR #3 starts with `modify_thread`
+ * (trivial wrapper over `gmail.users.threads.modify`); PR #6 extends
+ * with `get_thread`, `list_inbox_threads`, and
+ * `get_inbox_with_threads`. Once every thread-domain tool lives here,
+ * PR #7 deletes the corresponding switch arms from the legacy
+ * dispatcher in `src/index.ts`.
+ */
+
+import type { gmail_v1 } from "googleapis";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defineTool } from "./_shared.js";
+import { getToolByName, ModifyThreadSchema } from "../tools.js";
+
+function pull(name: string) {
+  const def = getToolByName(name);
+  if (!def) {
+    throw new Error(`Tool definition missing: ${name}`);
+  }
+  return { description: def.description, scopes: def.scopes, annotations: def.annotations };
+}
+
+export function registerThreadTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  authorizedScopes: readonly string[],
+): void {
+  const modifyThread = pull("modify_thread");
+  defineTool(
+    server,
+    "modify_thread",
+    modifyThread.description,
+    ModifyThreadSchema.shape,
+    async (args) => {
+      const requestBody: Record<string, unknown> = {};
+      if (args.addLabelIds) {
+        requestBody.addLabelIds = args.addLabelIds;
+      }
+      if (args.removeLabelIds) {
+        requestBody.removeLabelIds = args.removeLabelIds;
+      }
+      await gmail.users.threads.modify({
+        userId: "me",
+        id: args.threadId,
+        requestBody,
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Thread ${args.threadId} labels updated successfully (all messages in thread modified)`,
+          },
+        ],
+      };
+    },
+    modifyThread.annotations,
+    modifyThread.scopes,
+    authorizedScopes,
+  );
+}


### PR DESCRIPTION
## Why

Step **#3 of 7** toward v1.0.0. Introduces the per-domain registrar modules (\`src/tools/{messages,labels,filters,threads}.ts\`) that PR #4-#6 will extend. Each registrar uses the \`defineTool()\` helper from PR #2 and the OAuth scope filter is applied at registration time.

This PR migrates only the tools that are pure trivial wrappers over their existing helpers — no new logic, just routing through the new infrastructure.

## Base branch

\`feat/v1-pr2-mcp-server-factory\` (depends on \`defineTool\` introduced there). Once PR #2 (#84) merges into \`main\`, this PR's base will switch to \`main\`.

## Tools migrated

| Tool | New file | Handler |
|---|---|---|
| \`delete_email\` | \`src/tools/messages.ts\` | \`gmail.users.messages.delete\` |
| \`delete_label\` | \`src/tools/labels.ts\` | \`deleteLabel(gmail, id)\` |
| \`delete_filter\` | \`src/tools/filters.ts\` | \`deleteFilter(gmail, filterId)\` |
| \`modify_thread\` | \`src/tools/threads.ts\` | \`gmail.users.threads.modify\` |

## Why split from #4 / #5 / #6

These four tools have no dependency on PR #1's \`sendOrDraftEmail\` extraction. They can ship today, validating the \`defineTool\` pattern end-to-end. Tools that DO depend on \`sendOrDraftEmail\` (\`send_email\`, \`draft_email\`, \`reply_all\`) land in a later PR built on top of both PR #1 and PR #2.

## Tests (8 in \`src/tools/registrars.test.ts\`)

E2E via \`Client\` + \`InMemoryTransport\` pinning the entire production path:

- \`delete_email\`: forwards messageId; only advertised with \`mail.google.com\` (\`gmail.modify\` rejected as designed)
- \`delete_label\`: forwards id (with the \`gmail.users.labels.get\` pre-flight that \`deleteLabel\` does to refuse system labels)
- \`delete_filter\`: forwards filterId via \`gmail.users.settings.filters.delete\`
- \`modify_thread\`: forwards addLabelIds + removeLabelIds; AND omits empty arrays from request body
- \`tools/list\` shape: advertises all 4 when scopes cover, filters down when they don't

**Total: 458 → 466 (+8).** The 4 new registrars are at 100% lines.

## Important: legacy dispatcher unchanged

The \`CallToolRequestSchema\` switch in \`src/index.ts\` still owns all 26 tool cases in production. These new registrars are tested directly but not yet wired into the entry point. PR #7 performs the atomic switchover.

## Checklist

- [x] Title ≤ 72 chars (66)
- [x] Tests green (\`npm test\`: 466 passed)
- [x] Lint clean
- [x] Format clean
- [x] Build green
- [x] No new runtime dependency
- [x] Signed commit