### PR TITLE
feat(tools): register downloads + thread tools via defineTool

### DIFF
--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -1,0 +1,196 @@
+/**
+ * Download-domain tool registrars (`download_email`, `download_attachment`).
+ * Both tools write a file under the `GMAIL_MCP_DOWNLOAD_DIR` jail
+ * (default `~/GmailDownloads`) via `safeWriteFile` (O_NOFOLLOW on the
+ * leaf, O_EXCL against silent overwrites). PR #7 deletes the
+ * corresponding switch arms from the legacy dispatcher in
+ * `src/index.ts`.
+ */
+
+import path from "path";
+import fs from "fs";
+import type { gmail_v1 } from "googleapis";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { defineTool, pullToolMeta as pull } from "./_shared.js";
+import { DownloadEmailSchema, DownloadAttachmentSchema } from "../tools.js";
+import {
+  resolveDownloadSavePath,
+  getDownloadDir,
+  safeWriteFile,
+  sanitizeAttachmentFilename,
+} from "../utl.js";
+import { extractHeaders } from "../gmail-headers.js";
+import { extractEmailContent, extractAttachments } from "../mime-walkers.js";
+import { gmailMessageToJson, emailToTxt, emailToHtml } from "../email-export.js";
+import { asGmailApiError } from "../gmail-errors.js";
+
+type GmailMessagePart = gmail_v1.Schema$MessagePart;
+
+export function registerDownloadTools(
+  server: McpServer,
+  gmail: gmail_v1.Gmail,
+  authorizedScopes: readonly string[],
+): void {
+  // download_email
+  const downloadEmail = pull("download_email");
+  defineTool(
+    server,
+    "download_email",
+    downloadEmail.description,
+    DownloadEmailSchema.shape,
+    async (args) => {
+      const { messageId, format } = args;
+      try {
+        const savePath = resolveDownloadSavePath(args.savePath);
+        // `full` carries headers + payload tree; `raw` only when
+        // format=eml. Issue both in parallel so EML downloads do not
+        // pay a second round-trip after the full fetch returns.
+        const [fullResponse, rawResponse] = await Promise.all([
+          gmail.users.messages.get({ userId: "me", id: messageId, format: "full" }),
+          format === "eml"
+            ? gmail.users.messages.get({ userId: "me", id: messageId, format: "raw" })
+            : Promise.resolve(null),
+        ]);
+
+        const { subject, from, date } = extractHeaders(fullResponse.data.payload);
+        const attachments = extractAttachments(fullResponse.data.payload as GmailMessagePart);
+
+        let content: string;
+        if (format === "eml") {
+          content = Buffer.from(rawResponse!.data.raw || "", "base64url").toString("utf-8");
+        } else {
+          const emailContent = extractEmailContent(
+            (fullResponse.data.payload as GmailMessagePart) || {},
+          );
+          if (format === "json") {
+            const jsonData = gmailMessageToJson(fullResponse.data, emailContent, attachments);
+            content = JSON.stringify(jsonData, null, 2);
+          } else if (format === "txt") {
+            content = emailToTxt(fullResponse.data, emailContent, attachments);
+          } else {
+            content = emailToHtml(emailContent);
+          }
+        }
+
+        const filename = `${messageId}.${format}`;
+        const requestedPath = path.join(savePath, filename);
+        const writtenPath = safeWriteFile(requestedPath, content, { onCollision: "suffix" });
+        const stats = fs.statSync(writtenPath);
+
+        const result = {
+          status: "saved",
+          path: writtenPath,
+          size: stats.size,
+          messageId,
+          subject,
+          from,
+          date,
+          attachments,
+        };
+        return {
+          content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+        };
+      } catch (error: unknown) {
+        const { code, message } = asGmailApiError(error);
+        const prefix =
+          code !== undefined
+            ? `Failed to download email (HTTP ${code})`
+            : "Failed to download email";
+        return {
+          content: [{ type: "text", text: `${prefix}: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+    downloadEmail.annotations,
+    downloadEmail.scopes,
+    authorizedScopes,
+  );
+
+  // download_attachment
+  const downloadAttachment = pull("download_attachment");
+  defineTool(
+    server,
+    "download_attachment",
+    downloadAttachment.description,
+    DownloadAttachmentSchema.shape,
+    async (args) => {
+      try {
+        const attachmentResponse = await gmail.users.messages.attachments.get({
+          userId: "me",
+          messageId: args.messageId,
+          id: args.attachmentId,
+        });
+
+        if (!attachmentResponse.data.data) {
+          throw new Error("No attachment data received");
+        }
+
+        const data = attachmentResponse.data.data;
+        const buffer = Buffer.from(data, "base64url");
+
+        const savePath = resolveDownloadSavePath(args.savePath ?? getDownloadDir());
+        let filename = args.filename;
+
+        if (!filename) {
+          const messageResponse = await gmail.users.messages.get({
+            userId: "me",
+            id: args.messageId,
+            format: "full",
+          });
+
+          const findAttachment = (part: GmailMessagePart): string | null => {
+            if (part.body && part.body.attachmentId === args.attachmentId) {
+              return part.filename || `attachment-${args.attachmentId}`;
+            }
+            if (part.parts) {
+              for (const subpart of part.parts) {
+                const found = findAttachment(subpart);
+                if (found) return found;
+              }
+            }
+            return null;
+          };
+
+          filename =
+            (messageResponse.data.payload ? findAttachment(messageResponse.data.payload) : null) ||
+            `attachment-${args.attachmentId}`;
+        }
+
+        // Sanitize filename: backslash / NUL / C0 / control chars from
+        // a hostile sender's MIME `filename` attribute. Order matters:
+        // sanitize first so backslash-separated segments survive for
+        // basename to strip; belt-and-braces basename after.
+        filename = path.basename(sanitizeAttachmentFilename(filename));
+
+        const fullPath = path.resolve(savePath, filename);
+        if (!fullPath.startsWith(savePath + path.sep) && fullPath !== savePath) {
+          throw new Error("Invalid filename: path traversal detected");
+        }
+        const writtenPath = safeWriteFile(fullPath, buffer, { onCollision: "suffix" });
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Attachment downloaded successfully:\nFile: ${path.basename(writtenPath)}\nSize: ${buffer.length} bytes\nSaved to: ${writtenPath}`,
+            },
+          ],
+        };
+      } catch (error: unknown) {
+        const { code, message } = asGmailApiError(error);
+        const prefix =
+          code !== undefined
+            ? `Failed to download attachment (HTTP ${code})`
+            : "Failed to download attachment";
+        return {
+          content: [{ type: "text", text: `${prefix}: ${message}` }],
+          isError: true,
+        };
+      }
+    },
+    downloadAttachment.annotations,
+    downloadAttachment.scopes,
+    authorizedScopes,
+  );
+}

--- a/src/tools/registrars.test.ts
+++ b/src/tools/registrars.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, readdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import type { gmail_v1 } from "googleapis";
@@ -28,18 +28,25 @@ import { registerMessageTools } from "./messages.js";
 import { registerLabelTools } from "./labels.js";
 import { registerFilterTools } from "./filters.js";
 import { registerThreadTools } from "./threads.js";
+import { registerDownloadTools } from "./downloads.js";
 import { resetRateLimitHistory } from "../rate-limit.js";
+import { resetJailDirCache } from "../utl.js";
 
 // Per-test rate-limit isolation: each test gets its own GMAIL_MCP_STATE_DIR
 // so the persistent rate-limit ledger does not leak across tests (without
 // this, the ~20 filter-tool calls below the 24h cap of the "filters"
-// bucket and subsequent tests get 429-ed).
+// bucket and subsequent tests get 429-ed). Same for download-jail
+// (GMAIL_MCP_DOWNLOAD_DIR + the in-process jail-root cache) so the
+// download tests in PR #6 do not write to one another's directories.
 let stateDir: string;
+let downloadDir: string;
 const originalEnv = { ...process.env };
 
 beforeEach(() => {
   stateDir = mkdtempSync(join(tmpdir(), "gmail-mcp-registrars-test-"));
+  downloadDir = mkdtempSync(join(tmpdir(), "gmail-mcp-download-test-"));
   process.env.GMAIL_MCP_STATE_DIR = stateDir;
+  process.env.GMAIL_MCP_DOWNLOAD_DIR = downloadDir;
   delete process.env.GMAIL_MCP_RATE_LIMIT_DISABLE;
   for (const k of Object.keys(process.env)) {
     if (k.startsWith("GMAIL_MCP_RATE_LIMIT_") && k !== "GMAIL_MCP_RATE_LIMIT_DISABLE") {
@@ -47,12 +54,15 @@ beforeEach(() => {
     }
   }
   resetRateLimitHistory();
+  resetJailDirCache();
 });
 
 afterEach(() => {
   rmSync(stateDir, { recursive: true, force: true });
+  rmSync(downloadDir, { recursive: true, force: true });
   process.env = { ...originalEnv };
   resetRateLimitHistory();
+  resetJailDirCache();
 });
 
 interface MockedGmailCalls {
@@ -60,7 +70,10 @@ interface MockedGmailCalls {
   messageGet: Array<unknown>;
   messageList: Array<unknown>;
   messageModify: Array<unknown>;
+  attachmentGet: Array<unknown>;
   threadModify: Array<unknown>;
+  threadGet: Array<unknown>;
+  threadList: Array<unknown>;
   filterDelete: Array<unknown>;
   filterCreate: Array<unknown>;
   filterList: Array<unknown>;
@@ -87,6 +100,30 @@ interface MockGmailOpts {
    * `search_emails`.
    */
   searchResults?: Array<{ id: string; subject?: string; from?: string; date?: string }>;
+  /**
+   * Pre-existing thread structure returned by
+   * `gmail.users.threads.list` + `gmail.users.threads.get`. Keyed by
+   * threadId for the `get` lookup.
+   */
+  threads?: Record<
+    string,
+    {
+      snippet?: string;
+      historyId?: string;
+      messages: Array<{
+        id: string;
+        labelIds?: string[];
+        bodyText?: string;
+        from?: string;
+        subject?: string;
+      }>;
+    }
+  >;
+  /**
+   * Attachment payload returned by `gmail.users.messages.attachments.get`
+   * (base64url-encoded). Used by `download_attachment` tests.
+   */
+  attachmentData?: string;
 }
 
 function mockGmail(opts: MockGmailOpts = {}): {
@@ -98,7 +135,10 @@ function mockGmail(opts: MockGmailOpts = {}): {
     messageGet: [],
     messageList: [],
     messageModify: [],
+    attachmentGet: [],
     threadModify: [],
+    threadGet: [],
+    threadList: [],
     filterDelete: [],
     filterCreate: [],
     filterList: [],
@@ -111,6 +151,15 @@ function mockGmail(opts: MockGmailOpts = {}): {
   const client = {
     users: {
       messages: {
+        attachments: {
+          get: async (params: unknown) => {
+            calls.attachmentGet.push(params);
+            const data =
+              opts.attachmentData ??
+              Buffer.from("%PDF-1.4 fake pdf content", "utf-8").toString("base64url");
+            return { data: { data, size: data.length } };
+          },
+        },
         delete: async (params: unknown) => {
           calls.messageDelete.push(params);
           return { data: {} };
@@ -122,36 +171,45 @@ function mockGmail(opts: MockGmailOpts = {}): {
         get: async (params: unknown) => {
           calls.messageGet.push(params);
           const id = (params as { id?: string }).id ?? "msg_unknown";
+          const format = (params as { format?: string }).format ?? "full";
           // Build a minimal MIME tree with one text/plain part
           // carrying the supplied body. Sufficient for read_email's
-          // header + body + truncation logic.
+          // header + body + truncation logic, and for download_email
+          // (json/txt/html) which extracts the same shape.
           const bodyText = opts.messageBodyText ?? "default body content";
           const bodyB64 = Buffer.from(bodyText, "utf-8")
             .toString("base64")
             .replace(/\+/g, "-")
             .replace(/\//g, "_")
             .replace(/=+$/, "");
-          return {
-            data: {
-              id,
-              threadId: `thread_for_${id}`,
-              payload: {
-                headers: [
-                  { name: "From", value: "Alice <alice@example.com>" },
-                  { name: "To", value: "bob@example.com" },
-                  { name: "Subject", value: `Test message ${id}` },
-                  { name: "Date", value: "Fri, 25 Apr 2026 10:00:00 +0000" },
-                  { name: "Message-ID", value: `<${id}@example.com>` },
-                ],
-                parts: [
-                  {
-                    mimeType: "text/plain",
-                    body: { size: bodyText.length, data: bodyB64 },
-                  },
-                ],
-              },
+          const fullBase = {
+            id,
+            threadId: `thread_for_${id}`,
+            payload: {
+              headers: [
+                { name: "From", value: "Alice <alice@example.com>" },
+                { name: "To", value: "bob@example.com" },
+                { name: "Subject", value: `Test message ${id}` },
+                { name: "Date", value: "Fri, 25 Apr 2026 10:00:00 +0000" },
+                { name: "Message-ID", value: `<${id}@example.com>` },
+              ],
+              parts: [
+                {
+                  mimeType: "text/plain",
+                  body: { size: bodyText.length, data: bodyB64 },
+                },
+              ],
             },
           };
+          if (format === "raw") {
+            // download_email format=eml issues a separate raw fetch
+            // alongside the full one. Return a minimal RFC822 payload.
+            const rfc822 = `From: alice@example.com\r\nTo: bob@example.com\r\nSubject: Test message ${id}\r\n\r\n${bodyText}`;
+            return {
+              data: { ...fullBase, raw: Buffer.from(rfc822, "utf-8").toString("base64url") },
+            };
+          }
+          return { data: fullBase };
         },
         list: async (params: unknown) => {
           calls.messageList.push(params);
@@ -165,6 +223,58 @@ function mockGmail(opts: MockGmailOpts = {}): {
         modify: async (params: unknown) => {
           calls.threadModify.push(params);
           return { data: {} };
+        },
+        get: async (params: unknown) => {
+          calls.threadGet.push(params);
+          const id = (params as { id?: string }).id ?? "thread_unknown";
+          const t = opts.threads?.[id];
+          if (!t) {
+            return { data: { messages: [] } };
+          }
+          return {
+            data: {
+              messages: t.messages.map((m) => {
+                const bodyText = m.bodyText ?? "thread body";
+                const bodyB64 = Buffer.from(bodyText, "utf-8")
+                  .toString("base64")
+                  .replace(/\+/g, "-")
+                  .replace(/\//g, "_")
+                  .replace(/=+$/, "");
+                return {
+                  id: m.id,
+                  threadId: id,
+                  labelIds: m.labelIds ?? [],
+                  payload: {
+                    headers: [
+                      { name: "From", value: m.from ?? "alice@example.com" },
+                      { name: "Subject", value: m.subject ?? `Msg ${m.id}` },
+                      { name: "Date", value: "Fri, 25 Apr 2026 10:00:00 +0000" },
+                      { name: "Message-ID", value: `<${m.id}@example.com>` },
+                    ],
+                    parts: [
+                      {
+                        mimeType: "text/plain",
+                        body: { size: bodyText.length, data: bodyB64 },
+                      },
+                    ],
+                  },
+                };
+              }),
+            },
+          };
+        },
+        list: async (params: unknown) => {
+          calls.threadList.push(params);
+          const ids = Object.keys(opts.threads ?? {});
+          return {
+            data: {
+              threads: ids.map((id) => ({
+                id,
+                snippet: opts.threads?.[id]?.snippet ?? "",
+                historyId: opts.threads?.[id]?.historyId ?? "",
+              })),
+            },
+          };
         },
       },
       labels: {
@@ -285,6 +395,7 @@ async function buildAndConnect(
   registerLabelTools(server, gmail, scopes);
   registerFilterTools(server, gmail, scopes);
   registerThreadTools(server, gmail, scopes);
+  registerDownloadTools(server, gmail, scopes);
 
   const [serverTransport, clientTransport] = InMemoryTransport.createLinkedPair();
   const client = new Client({ name: "registrars-test", version: "0.0.0" });
@@ -808,8 +919,149 @@ describe("PR #5 registrars — modify_email + batch_*", () => {
   });
 });
 
-describe("PR #3+#4+#5 registrars — combined tools/list shape", () => {
-  it("advertises every PR-#3+#4+#5 tool when the token covers every required scope", async () => {
+describe("PR #6 registrars — download_email + download_attachment", () => {
+  it("download_email json format writes a JSON file under the download jail", async () => {
+    await withFix(["gmail.readonly"], async (fix) => {
+      const result = (await fix.client.callTool({
+        name: "download_email",
+        arguments: { messageId: "msg_dl_json", savePath: downloadDir, format: "json" },
+      })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const text = result.content[0]?.text ?? "";
+      expect(text).toContain('"status": "saved"');
+      expect(text).toContain("msg_dl_json.json");
+      // Verify the file actually exists in the jail.
+      const written = readdirSync(downloadDir);
+      expect(written).toContain("msg_dl_json.json");
+    });
+  });
+
+  it("download_email eml format issues both full+raw fetches in parallel", async () => {
+    await withFix(["gmail.readonly"], async (fix) => {
+      const result = (await fix.client.callTool({
+        name: "download_email",
+        arguments: { messageId: "msg_dl_eml", savePath: downloadDir, format: "eml" },
+      })) as { content: Array<{ type: string; text: string }> };
+      expect(result.content[0]?.text).toContain("msg_dl_eml.eml");
+      // Two get calls: one full, one raw.
+      expect(fix.calls.messageGet).toHaveLength(2);
+      const formats = fix.calls.messageGet.map((c) => (c as { format?: string }).format).sort();
+      expect(formats).toEqual(["full", "raw"]);
+    });
+  });
+
+  it("download_attachment writes the bytes under the download jail", async () => {
+    await withFix(["gmail.modify"], async (fix) => {
+      const result = (await fix.client.callTool({
+        name: "download_attachment",
+        arguments: {
+          messageId: "msg_with_att",
+          attachmentId: "att_1",
+          filename: "report.pdf",
+          savePath: downloadDir,
+        },
+      })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      expect(result.content[0]?.text).toContain("report.pdf");
+      const written = readdirSync(downloadDir);
+      expect(written).toContain("report.pdf");
+    });
+  });
+});
+
+describe("PR #6 registrars — get_thread + list_inbox_threads + get_inbox_with_threads", () => {
+  const fixtureThreads = {
+    thread_a: {
+      snippet: "thread A snippet",
+      historyId: "h1",
+      messages: [
+        { id: "m1", from: "alice@example.com", subject: "First", bodyText: "First body" },
+        { id: "m2", from: "bob@example.com", subject: "Second", bodyText: "Second body" },
+      ],
+    },
+    thread_b: {
+      snippet: "thread B snippet",
+      historyId: "h2",
+      messages: [{ id: "m3", from: "carol@example.com", subject: "Third", bodyText: "Body 3" }],
+    },
+  };
+
+  it("get_thread returns each message's headers + body in JSON", async () => {
+    await withFix(
+      ["gmail.readonly"],
+      async (fix) => {
+        const result = (await fix.client.callTool({
+          name: "get_thread",
+          arguments: { threadId: "thread_a" },
+        })) as { content: Array<{ type: string; text: string }> };
+        const text = result.content[0]?.text ?? "";
+        expect(text).toContain('"messageCount": 2');
+        expect(text).toContain("First body");
+        expect(text).toContain("Second body");
+        expect(text).toContain("alice@example.com");
+        expect(text).toContain("bob@example.com");
+      },
+      { threads: fixtureThreads },
+    );
+  });
+
+  it("list_inbox_threads returns a metadata summary per thread", async () => {
+    await withFix(
+      ["gmail.readonly"],
+      async (fix) => {
+        const result = (await fix.client.callTool({
+          name: "list_inbox_threads",
+          arguments: { query: "in:inbox", maxResults: 10 },
+        })) as { content: Array<{ type: string; text: string }> };
+        const text = result.content[0]?.text ?? "";
+        expect(text).toContain('"resultCount": 2');
+        expect(text).toContain("thread_a");
+        expect(text).toContain("thread_b");
+        // Latest message metadata pulled.
+        expect(text).toContain("Second");
+      },
+      { threads: fixtureThreads },
+    );
+  });
+
+  it("get_inbox_with_threads expandThreads=false returns the lightweight summary", async () => {
+    await withFix(
+      ["gmail.readonly"],
+      async (fix) => {
+        const result = (await fix.client.callTool({
+          name: "get_inbox_with_threads",
+          arguments: { expandThreads: false, query: "in:inbox", maxResults: 10 },
+        })) as { content: Array<{ type: string; text: string }> };
+        const text = result.content[0]?.text ?? "";
+        expect(text).toContain("thread_a");
+        // Summary path → no body content rendered.
+        expect(text).not.toContain("First body");
+      },
+      { threads: fixtureThreads },
+    );
+  });
+
+  it("get_inbox_with_threads expandThreads=true fetches and renders every message body", async () => {
+    await withFix(
+      ["gmail.readonly"],
+      async (fix) => {
+        const result = (await fix.client.callTool({
+          name: "get_inbox_with_threads",
+          arguments: { expandThreads: true, query: "in:inbox", maxResults: 10 },
+        })) as { content: Array<{ type: string; text: string }> };
+        const text = result.content[0]?.text ?? "";
+        // Both bodies rendered.
+        expect(text).toContain("First body");
+        expect(text).toContain("Second body");
+        expect(text).toContain("Body 3");
+      },
+      { threads: fixtureThreads },
+    );
+  });
+});
+
+describe("PR #3+#4+#5+#6 registrars — combined tools/list shape", () => {
+  it("advertises every PR-#3+#4+#5+#6 tool when the token covers every required scope", async () => {
     await withFix(
       ["mail.google.com", "gmail.modify", "gmail.labels", "gmail.settings.basic", "gmail.readonly"],
       async (fix) => {
@@ -824,10 +1076,15 @@ describe("PR #3+#4+#5 registrars — combined tools/list shape", () => {
           "delete_email",
           "delete_filter",
           "delete_label",
+          "download_attachment",
+          "download_email",
           "get_filter",
+          "get_inbox_with_threads",
           "get_or_create_label",
+          "get_thread",
           "list_email_labels",
           "list_filters",
+          "list_inbox_threads",
           "modify_email",
           "modify_thread",
           "read_email",

--- a/src/tools/threads.ts
+++ b/src/tools/threads.ts
@@ -1,22 +1,35 @@
 /**
- * Thread-domain tool registrars. PR #3 starts with `modify_thread`
- * (trivial wrapper over `gmail.users.threads.modify`); PR #6 extends
- * with `get_thread`, `list_inbox_threads`, and
- * `get_inbox_with_threads`. Once every thread-domain tool lives here,
- * PR #7 deletes the corresponding switch arms from the legacy
- * dispatcher in `src/index.ts`.
+ * Thread-domain tool registrars. PR #3 introduced the file with
+ * `modify_thread`. PR #6 extends with `get_thread`,
+ * `list_inbox_threads`, and `get_inbox_with_threads`. PR #7 deletes
+ * the corresponding switch arms from the legacy dispatcher in
+ * `src/index.ts`.
  */
 
 import type { gmail_v1 } from "googleapis";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { defineTool, pullToolMeta as pull } from "./_shared.js";
-import { ModifyThreadSchema } from "../tools.js";
+import {
+  ModifyThreadSchema,
+  GetThreadSchema,
+  ListInboxThreadsSchema,
+  GetInboxWithThreadsSchema,
+} from "../tools.js";
+import { pickBodyAnnotated } from "../utl.js";
+import { extractEmailContent, collectAttachmentsForThread } from "../mime-walkers.js";
+
+type GmailMessagePart = gmail_v1.Schema$MessagePart;
+
+function getH(headers: gmail_v1.Schema$MessagePartHeader[] | undefined, name: string): string {
+  return headers?.find((h) => h.name?.toLowerCase() === name.toLowerCase())?.value || "";
+}
 
 export function registerThreadTools(
   server: McpServer,
   gmail: gmail_v1.Gmail,
   authorizedScopes: readonly string[],
 ): void {
+  // modify_thread — PR #3
   const modifyThread = pull("modify_thread");
   defineTool(
     server,
@@ -25,12 +38,8 @@ export function registerThreadTools(
     ModifyThreadSchema.shape,
     async (args) => {
       const requestBody: Record<string, unknown> = {};
-      if (args.addLabelIds) {
-        requestBody.addLabelIds = args.addLabelIds;
-      }
-      if (args.removeLabelIds) {
-        requestBody.removeLabelIds = args.removeLabelIds;
-      }
+      if (args.addLabelIds) requestBody.addLabelIds = args.addLabelIds;
+      if (args.removeLabelIds) requestBody.removeLabelIds = args.removeLabelIds;
       await gmail.users.threads.modify({
         userId: "me",
         id: args.threadId,
@@ -47,6 +56,266 @@ export function registerThreadTools(
     },
     modifyThread.annotations,
     modifyThread.scopes,
+    authorizedScopes,
+  );
+
+  // get_thread — PR #6
+  const getThread = pull("get_thread");
+  defineTool(
+    server,
+    "get_thread",
+    getThread.description,
+    GetThreadSchema.shape,
+    async (args) => {
+      const threadResponse = await gmail.users.threads.get({
+        userId: "me",
+        id: args.threadId,
+        format: args.format || "full",
+      });
+      const threadMessages = threadResponse.data.messages || [];
+
+      const messagesOutput = threadMessages.map((msg) => {
+        const headers = msg.payload?.headers;
+        const subject = getH(headers, "subject");
+        const from = getH(headers, "from");
+        const to = getH(headers, "to");
+        const cc = getH(headers, "cc");
+        const bcc = getH(headers, "bcc");
+        const date = getH(headers, "date");
+
+        let body = "";
+        if (args.format !== "minimal") {
+          const { text, html } = extractEmailContent((msg.payload as GmailMessagePart) || {});
+          body = pickBodyAnnotated(text, html).body;
+        }
+
+        const attachments = msg.payload
+          ? collectAttachmentsForThread(msg.payload, "get_thread.processAttachmentParts")
+          : [];
+
+        return {
+          messageId: msg.id || "",
+          threadId: msg.threadId || "",
+          from,
+          to,
+          cc,
+          bcc,
+          subject,
+          date,
+          body,
+          labelIds: msg.labelIds || [],
+          attachments: attachments.map((a) => ({
+            filename: a.filename,
+            mimeType: a.mimeType,
+            size: a.size,
+          })),
+        };
+      });
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              {
+                threadId: args.threadId,
+                messageCount: messagesOutput.length,
+                messages: messagesOutput,
+              },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+    getThread.annotations,
+    getThread.scopes,
+    authorizedScopes,
+  );
+
+  // list_inbox_threads — PR #6
+  const listInboxThreads = pull("list_inbox_threads");
+  defineTool(
+    server,
+    "list_inbox_threads",
+    listInboxThreads.description,
+    ListInboxThreadsSchema.shape,
+    async (args) => {
+      const threadsResponse = await gmail.users.threads.list({
+        userId: "me",
+        q: args.query || "in:inbox",
+        maxResults: args.maxResults || 50,
+      });
+      const threads = threadsResponse.data.threads || [];
+
+      const threadDetails = await Promise.all(
+        threads.map(async (thread) => {
+          const detail = await gmail.users.threads.get({
+            userId: "me",
+            id: thread.id!,
+            format: "metadata",
+            metadataHeaders: ["Subject", "From", "Date"],
+          });
+          const messages = detail.data.messages || [];
+          const latestMessage = messages[messages.length - 1];
+          const latestHeaders = latestMessage?.payload?.headers;
+
+          return {
+            threadId: thread.id || "",
+            snippet: thread.snippet || "",
+            historyId: thread.historyId || "",
+            messageCount: messages.length,
+            latestMessage: {
+              from: getH(latestHeaders, "From"),
+              subject: getH(latestHeaders, "Subject"),
+              date: getH(latestHeaders, "Date"),
+            },
+          };
+        }),
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { resultCount: threadDetails.length, threads: threadDetails },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+    listInboxThreads.annotations,
+    listInboxThreads.scopes,
+    authorizedScopes,
+  );
+
+  // get_inbox_with_threads — PR #6
+  const getInboxWithThreads = pull("get_inbox_with_threads");
+  defineTool(
+    server,
+    "get_inbox_with_threads",
+    getInboxWithThreads.description,
+    GetInboxWithThreadsSchema.shape,
+    async (args) => {
+      const threadsResponse = await gmail.users.threads.list({
+        userId: "me",
+        q: args.query || "in:inbox",
+        maxResults: args.maxResults || 50,
+      });
+      const threads = threadsResponse.data.threads || [];
+
+      if (!args.expandThreads) {
+        const threadSummaries = await Promise.all(
+          threads.map(async (thread) => {
+            const detail = await gmail.users.threads.get({
+              userId: "me",
+              id: thread.id!,
+              format: "metadata",
+              metadataHeaders: ["Subject", "From", "Date"],
+            });
+            const messages = detail.data.messages || [];
+            const latestMessage = messages[messages.length - 1];
+            const latestHeaders = latestMessage?.payload?.headers;
+            return {
+              threadId: thread.id || "",
+              snippet: thread.snippet || "",
+              historyId: thread.historyId || "",
+              messageCount: messages.length,
+              latestMessage: {
+                from: getH(latestHeaders, "From"),
+                subject: getH(latestHeaders, "Subject"),
+                date: getH(latestHeaders, "Date"),
+              },
+            };
+          }),
+        );
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify(
+                { resultCount: threadSummaries.length, threads: threadSummaries },
+                null,
+                2,
+              ),
+            },
+          ],
+        };
+      }
+
+      // Expand each thread with full message content (parallel fetch)
+      const expandedThreads = await Promise.all(
+        threads.map(async (thread) => {
+          const threadDetail = await gmail.users.threads.get({
+            userId: "me",
+            id: thread.id!,
+            format: "full",
+          });
+          const threadMessages = threadDetail.data.messages || [];
+          const messages = threadMessages.map((msg) => {
+            const headers = msg.payload?.headers;
+            const subject = getH(headers, "subject");
+            const from = getH(headers, "from");
+            const to = getH(headers, "to");
+            const cc = getH(headers, "cc");
+            const bcc = getH(headers, "bcc");
+            const date = getH(headers, "date");
+
+            const { text, html } = extractEmailContent((msg.payload as GmailMessagePart) || {});
+            const body = pickBodyAnnotated(text, html).body;
+
+            const attachments = msg.payload
+              ? collectAttachmentsForThread(
+                  msg.payload,
+                  "get_inbox_with_threads.processAttachmentParts",
+                )
+              : [];
+
+            return {
+              messageId: msg.id || "",
+              threadId: msg.threadId || "",
+              from,
+              to,
+              cc,
+              bcc,
+              subject,
+              date,
+              body,
+              labelIds: msg.labelIds || [],
+              attachments: attachments.map((a) => ({
+                filename: a.filename,
+                mimeType: a.mimeType,
+                size: a.size,
+              })),
+            };
+          });
+          return {
+            threadId: thread.id || "",
+            messageCount: messages.length,
+            messages,
+          };
+        }),
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(
+              { resultCount: expandedThreads.length, threads: expandedThreads },
+              null,
+              2,
+            ),
+          },
+        ],
+      };
+    },
+    getInboxWithThreads.annotations,
+    getInboxWithThreads.scopes,
     authorizedScopes,
   );
 }


### PR DESCRIPTION
## Why

Step **#6 of 7** toward v1.0.0. Migrates 5 more tools (downloads + thread navigation) — leaves only the 3 messaging tools (\`send_email\`, \`draft_email\`, \`pair_recipient\`, \`reply_all\`) for PR #7's atomic switchover.

## Tools migrated (5)

**Downloads** (\`src/tools/downloads.ts\` — new file):
- \`download_email\` (json / eml / txt / html; parallel full+raw fetch when format=eml)
- \`download_attachment\` (recursive findAttachment, sanitize+basename+path-traversal guard)

**Threads** (\`src/tools/threads.ts\` — extends PR #3's stub):
- \`get_thread\` (per-message header + body + attachment loop)
- \`list_inbox_threads\` (parallel metadata fetch)
- \`get_inbox_with_threads\` (two branches: summary vs expand)

## Tests (7 E2E via Client + InMemoryTransport)

| Tool | Coverage |
|---|---|
| \`download_email\` json | file written under jail, "saved" status in result |
| \`download_email\` eml | both full+raw get calls issued in parallel |
| \`download_attachment\` | file written, supplied filename used |
| \`get_thread\` | each message's header+body in JSON output |
| \`list_inbox_threads\` | metadata-only summary per thread |
| \`get_inbox_with_threads\` (false) | no body content |
| \`get_inbox_with_threads\` (true) | every body rendered |

Combined tools/list shape test now expects **22 tools** (5 new).

**Total: 498 → 510 (+12).**

## Test infrastructure

Per-test \`GMAIL_MCP_DOWNLOAD_DIR\` (\`mkdtempSync\`) + \`resetJailDirCache()\` to isolate the in-process jail-root cache, so download tests do not write to one another's directories. Mirrors the existing rate-limit isolation pattern.

## Base branch

\`feat/v1-pr2-mcp-server-factory\` (the running cumulative branch with PR #2 + #3 + #4 + #5 + the CR fix-up commits).

## Checklist

- [x] PR title ≤ 72 chars (62)
- [x] Tests green (510 passed)
- [x] Lint clean
- [x] Format clean
- [x] Build green
- [x] No new runtime dependency
- [x] Signed commit