### PR TITLE
refactor(oauth): extract loadCredentials + authenticate

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -28,14 +28,23 @@ coverage:
     - "**/*.json"
     - ".github/**"
     - "scripts/**"
-    # `src/index.ts` is now a thin entry point: `loadCredentials` +
-    # `authenticate` (CLI auth flow only) + `main()` that builds the
-    # gmail client and hands off to `createServer`. The OAuth callback
-    # path runs only during `npx … auth` (interactive flow); the
-    # Gmail-credentials-not-configured error paths are tested via
-    # `gmail-errors.test.ts` and `lazy-boot.test.ts`. The remaining
-    # uncovered surface is the `getAccessToken` startup probe and
-    # the bootstrap glue, which is exercised via integration runs.
+    # `src/index.ts` is the thin CLI entry point. The OAuth flow
+    # (`loadCredentials` + `authenticate`) was extracted into
+    # `src/oauth-flow.ts` so it could be unit-tested without invoking
+    # `main()` on import — `oauth-flow.test.ts` now covers the
+    # lazy-boot path, the `installed`/`web` keys variants, the legacy
+    # vs v1.2.0+ credentials shape, the cwd-keys-copy + 0o600 chmod,
+    # the invalid-keys exit, and the authenticate() URL/port/listen
+    # rejection branches at ~92% statements.
+    #
+    # What remains in `src/index.ts` is bootstrap-only: argv parsing
+    # (callback URL + `--scopes`), `GMAIL_MCP_TIMEOUT_MS` parsing,
+    # the `google.options` + `google.gmail` + `createServer` +
+    # `transport.connect` glue, and the fire-and-forget
+    # `getAccessToken` startup probe. None of those are reachable
+    # without invoking `main()` (which boots a real stdio server),
+    # so they stay ignored until a future `runServer()` extraction
+    # makes them testable.
     #
     # `tools.ts` and `tools-coercion.ts` carry the long Zod schema
     # definitions + the tool registry array; the schemas themselves

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,24 +2,12 @@
 
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { google } from "googleapis";
-import { OAuth2Client } from "google-auth-library";
-import fs from "fs";
 import path from "path";
-import { fileURLToPath } from "url";
-import http from "http";
-import open from "open";
 import os from "os";
-import {
-  DEFAULT_SCOPES,
-  scopeNamesToUrls,
-  parseScopes,
-  validateScopes,
-  getAvailableScopeNames,
-} from "./scopes.js";
+import { DEFAULT_SCOPES, parseScopes, validateScopes, getAvailableScopeNames } from "./scopes.js";
 import { buildInvalidGrantPayload, isInvalidGrantError } from "./gmail-errors.js";
 import { createServer } from "./server.js";
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
+import { loadCredentials, authenticate } from "./oauth-flow.js";
 
 // Configuration paths
 const CONFIG_DIR = path.join(os.homedir(), ".gmail-mcp");
@@ -27,251 +15,29 @@ const OAUTH_PATH = process.env.GMAIL_OAUTH_PATH || path.join(CONFIG_DIR, "gcp-oa
 const CREDENTIALS_PATH =
   process.env.GMAIL_CREDENTIALS_PATH || path.join(CONFIG_DIR, "credentials.json");
 
-// OAuth2 configuration. The two `let` bindings persist across the boot
-// sequence; both are mutated by `loadCredentials()` once and then
-// passed into `createServer()` by `main()`.
-let oauth2Client: OAuth2Client;
-let oauthCallbackUrl: string;
-let authorizedScopes: string[] = DEFAULT_SCOPES;
-
-function loadCredentials() {
-  try {
-    // Create config directory if it doesn't exist
-    if (
-      !process.env.GMAIL_OAUTH_PATH &&
-      !process.env.GMAIL_CREDENTIALS_PATH &&
-      !fs.existsSync(CONFIG_DIR)
-    ) {
-      fs.mkdirSync(CONFIG_DIR, { recursive: true, mode: 0o700 });
-    }
-
-    // Check for OAuth keys in current directory first, then in config directory
-    const localOAuthPath = path.join(process.cwd(), "gcp-oauth.keys.json");
-
-    if (fs.existsSync(localOAuthPath)) {
-      // If found in current directory, copy to config directory.
-      // The CONFIG_DIR guard above skips mkdirSync when only
-      // GMAIL_CREDENTIALS_PATH is overridden — but OAUTH_PATH still
-      // defaults under ~/.gmail-mcp in that case, so without this
-      // explicit mkdir the copy would ENOENT. Also force 0o600 on
-      // the copy: copyFileSync preserves the source mode, so a 0o644
-      // `gcp-oauth.keys.json` sitting in cwd would keep that mode.
-      fs.mkdirSync(path.dirname(OAUTH_PATH), { recursive: true, mode: 0o700 });
-      fs.copyFileSync(localOAuthPath, OAUTH_PATH);
-      fs.chmodSync(OAUTH_PATH, 0o600);
-      console.error("OAuth keys found in current directory, copied to global config.");
-    }
-
-    if (!fs.existsSync(OAUTH_PATH)) {
-      // Lazy-boot mode: no OAuth keys at startup. Hosted MCP runners
-      // (Glama, Smithery, etc.) run a smoke test on `tools/list` before
-      // the user has any chance to mount credentials, and exiting here
-      // would mark the server as broken on the registry. Boot with a
-      // stub OAuth2Client instead — `tools/list` (which does not touch
-      // gmail.users.*) succeeds, and any tool call that needs auth
-      // fails cleanly through the `asGmailApiError` path with an
-      // `INVALID_GRANT`-shaped payload that surfaces the missing-auth
-      // condition to the agent.
-      console.error(
-        "Warning: OAuth keys file not found at",
-        OAUTH_PATH,
-        "— booting in lazy-auth mode. Tool calls that need Gmail will fail until `npx @klodr/gmail-mcp auth` is run.",
-      );
-      oauth2Client = new OAuth2Client();
-      // Narrow the advertised tool surface to the empty set until
-      // credentials are mounted — none of the 26 Gmail tools can
-      // succeed without an authorised scope, so advertising them on
-      // `tools/list` is misleading to agent operators inspecting
-      // capabilities pre-auth. `tools/list` then returns `[]`, and the
-      // first authenticated `tools/list` (post `npx @klodr/gmail-mcp
-      // auth`) sees the real surface.
-      authorizedScopes = [];
-      return;
-    }
-
-    const keysContent = JSON.parse(fs.readFileSync(OAUTH_PATH, "utf8"));
-    const keys = keysContent.installed || keysContent.web;
-
-    if (!keys) {
-      console.error(
-        'Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.',
-      );
-      process.exit(1);
-    }
-
-    // Parse callback URL from args (must be a URL, not a flag).
-    // Only loopback callbacks are supported (hostname must resolve to
-    // localhost / 127.0.0.1 / ::1); non-loopback targets would require
-    // an externally reachable endpoint, which this flow does not set up.
-    // Supports: node index.js auth http://localhost:8080/oauth2callback
-    // Or: node index.js auth --scopes=gmail.readonly (uses default callback)
-    const callbackArg = process.argv.find(
-      (arg) => arg.startsWith("http://") || arg.startsWith("https://"),
-    );
-    oauthCallbackUrl = callbackArg || "http://localhost:3000/oauth2callback";
-
-    oauth2Client = new OAuth2Client(keys.client_id, keys.client_secret, oauthCallbackUrl);
-
-    if (fs.existsSync(CREDENTIALS_PATH)) {
-      const credentials = JSON.parse(fs.readFileSync(CREDENTIALS_PATH, "utf8"));
-
-      // Credentials file structure (v1.2.0+):
-      //   { "tokens": { access_token, refresh_token, ... }, "scopes": ["gmail.readonly", ...] }
-      //
-      // Legacy structure (pre-v1.2.0):
-      //   { access_token, refresh_token, ... }
-      //
-      // We support both formats for backwards compatibility. Users with legacy
-      // credentials will get DEFAULT_SCOPES (full access) until they re-authenticate.
-      const tokens = credentials.tokens || credentials;
-      oauth2Client.setCredentials(tokens);
-
-      if (credentials.scopes) {
-        authorizedScopes = credentials.scopes;
-      }
-    }
-  } catch (error) {
-    // Log only the error message, not the full Error object — a JSON.parse
-    // failure on a partially-corrupted OAuth file carries a snippet of
-    // the faulty content (position/line pointer) that could include
-    // client_secret if the corruption landed near it. Stderr is forwarded
-    // to the MCP host's logs.
-    const msg = error instanceof Error ? error.message : String(error);
-    console.error(`Error loading credentials: ${msg}`);
-    process.exit(1);
-  }
-}
-
-async function authenticate(scopes: string[]) {
-  const parsed = new URL(oauthCallbackUrl);
-
-  // The built-in callback listener is plain http.createServer(). If the
-  // caller passes an https:// URL, OAuth would redirect to a TLS target
-  // that nothing on this process is listening on — silent failure.
-  if (parsed.protocol !== "http:") {
-    throw new Error(
-      `Callback protocol '${parsed.protocol}' is not supported. ` +
-        `The built-in auth server only accepts loopback HTTP callbacks (http://localhost...).`,
-    );
-  }
-
-  const hostname = parsed.hostname;
-  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
-
-  if (!isLoopback) {
-    throw new Error(
-      `Callback hostname '${hostname}' is not loopback. ` +
-        `Only http://localhost / 127.0.0.1 / [::1] are supported by the built-in ` +
-        `auth flow. Either (a) rerun 'auth' without a positional callback URL, ` +
-        `or (b) point your Web OAuth client at a loopback URL.`,
-    );
-  }
-
-  const port = parsed.port ? Number(parsed.port) : 80;
-  // Range-check the callback port up-front. The built-in auth server
-  // is a non-privileged loopback listener — privileged ports (1-1023)
-  // require root and are almost certainly a misconfiguration; ports
-  // outside 1-65535 are not valid TCP at all. Catching this here gives
-  // a clean error before `server.listen` would emit a less obvious
-  // EACCES/RANGE_ERR diagnostic.
-  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
-    throw new Error(
-      `Callback port '${parsed.port || "(default)"}' is invalid. ` +
-        `The built-in auth server requires an unprivileged TCP port (1024-65535). ` +
-        `Pick a free port in that range and pass it via the callback URL.`,
-    );
-  }
-  const callbackPath = parsed.pathname || "/oauth2callback";
-
-  const httpServer = http.createServer();
-  // Convert shorthand scope names (e.g., "gmail.readonly") to full Google API URLs
-  const scopeUrls = scopeNamesToUrls(scopes);
-
-  return new Promise<void>((resolve, reject) => {
-    // Surface listen-time failures (port in use, address bind, etc.)
-    // immediately. Without this listener, `server.listen` failures would
-    // crash the process via an `uncaughtException`, hiding the real
-    // cause behind a generic stack trace.
-    httpServer.on("error", (err: NodeJS.ErrnoException) => {
-      const hint =
-        err.code === "EADDRINUSE"
-          ? ` Another process is already listening on that port — pick a different one or stop the conflicting process.`
-          : err.code === "EACCES"
-            ? ` Insufficient privilege to bind that port — pick a port >= 1024.`
-            : "";
-      reject(
-        new Error(`OAuth callback server failed to listen on ${hostname}:${port}.${hint}`, {
-          cause: err,
-        }),
-      );
-    });
-    httpServer.listen(port, hostname);
-
-    const authUrl = oauth2Client.generateAuthUrl({
-      access_type: "offline",
-      scope: scopeUrls,
-    });
-
-    console.error("Requesting scopes:", scopes.join(", "));
-    console.error("Please visit this URL to authenticate:", authUrl);
-    void open(authUrl);
-
-    // Wrap bare IPv6 hostnames in brackets so `new URL()` accepts the base.
-    const hostForUrl = hostname.includes(":") ? `[${hostname}]` : hostname;
-    const baseUrl = `http://${hostForUrl}:${port}`;
-
-    httpServer.on("request", (req, res) => {
-      void (async () => {
-        if (!req.url) return;
-
-        const url = new URL(req.url, baseUrl);
-        // Exact pathname match — startsWith would let `/oauth2callback-evil`
-        // (or any extension) slip through on the loopback server.
-        if (url.pathname !== callbackPath) return;
-
-        const code = url.searchParams.get("code");
-
-        if (!code) {
-          res.writeHead(400);
-          res.end("No code provided");
-          reject(new Error("No code provided"));
-          return;
-        }
-
-        try {
-          const { tokens } = await oauth2Client.getToken(code);
-          oauth2Client.setCredentials(tokens);
-
-          // Store both tokens and authorized scopes for runtime filtering.
-          // writeFileSync's `mode` option only applies on CREATE, so an
-          // existing credentials.json with broader perms (e.g. 0o644
-          // from a prior setup) would keep those bytes after re-auth.
-          // Force 0o600 explicitly after write to match .github/SECURITY.md.
-          const credentials = { tokens, scopes };
-          fs.mkdirSync(path.dirname(CREDENTIALS_PATH), { recursive: true, mode: 0o700 });
-          fs.writeFileSync(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2), {
-            mode: 0o600,
-          });
-          fs.chmodSync(CREDENTIALS_PATH, 0o600);
-
-          res.writeHead(200);
-          res.end("Authentication successful! You can close this window.");
-          console.error("Credentials saved with scopes:", scopes.join(", "));
-          httpServer.close();
-          resolve();
-        } catch (error) {
-          res.writeHead(500);
-          res.end("Authentication failed");
-          reject(error instanceof Error ? error : new Error(String(error)));
-        }
-      })();
-    });
-  });
-}
-
 // Main function
 async function main() {
-  loadCredentials();
+  // Parse callback URL from args (must be a URL, not a flag).
+  // Only loopback callbacks are supported (hostname must resolve to
+  // localhost / 127.0.0.1 / ::1); non-loopback targets would require
+  // an externally reachable endpoint, which this flow does not set up.
+  // Supports: node index.js auth http://localhost:8080/oauth2callback
+  // Or: node index.js auth --scopes=gmail.readonly (uses default callback)
+  const callbackArg = process.argv.find(
+    (arg) => arg.startsWith("http://") || arg.startsWith("https://"),
+  );
+
+  const { oauth2Client, oauthCallbackUrl, authorizedScopes } = loadCredentials({
+    oauthPath: OAUTH_PATH,
+    credentialsPath: CREDENTIALS_PATH,
+    configDir: CONFIG_DIR,
+    // Skip auto-creating ~/.gmail-mcp when either env-var override is
+    // set: the operator pointed somewhere outside the default tree
+    // and may not want a stub directory created at $HOME.
+    skipConfigDirCreate:
+      Boolean(process.env.GMAIL_OAUTH_PATH) || Boolean(process.env.GMAIL_CREDENTIALS_PATH),
+    callbackArg,
+  });
 
   if (process.argv[2] === "auth") {
     // Parse --scopes flag from CLI arguments
@@ -279,7 +45,7 @@ async function main() {
     // Example: node dist/index.js auth --scopes=gmail.readonly
     // Example: node dist/index.js auth --scopes=gmail.readonly,gmail.settings.basic
     const scopesArg = process.argv.find((arg) => arg.startsWith("--scopes="));
-    let scopes = DEFAULT_SCOPES;
+    let scopes: string[] = [...DEFAULT_SCOPES];
 
     if (scopesArg) {
       const scopesValue = scopesArg.slice("--scopes=".length);
@@ -297,7 +63,22 @@ async function main() {
       console.error("Available scopes:", getAvailableScopeNames().join(", "));
     }
 
-    await authenticate(scopes);
+    if (!oauthCallbackUrl) {
+      // Lazy-boot mode: no OAuth keys present, so `loadCredentials`
+      // returned a stub client without a callback URL. Running `auth`
+      // here would have nowhere to redirect the OAuth grant.
+      console.error(
+        `Cannot run \`auth\` without OAuth keys at ${OAUTH_PATH}. Provide \`gcp-oauth.keys.json\` (download from Google Cloud Console → APIs & Services → Credentials).`,
+      );
+      process.exit(1);
+    }
+
+    await authenticate({
+      oauth2Client,
+      oauthCallbackUrl,
+      scopes,
+      credentialsPath: CREDENTIALS_PATH,
+    });
     console.error("Authentication completed successfully");
     process.exit(0);
   }
@@ -365,7 +146,7 @@ async function main() {
   });
 
   const gmail = google.gmail({ version: "v1", auth: oauth2Client });
-  const server = createServer({ gmail, authorizedScopes });
+  const server = createServer({ gmail, authorizedScopes: [...authorizedScopes] });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -146,7 +146,7 @@ async function main() {
   });
 
   const gmail = google.gmail({ version: "v1", auth: oauth2Client });
-  const server = createServer({ gmail, authorizedScopes: [...authorizedScopes] });
+  const server = createServer({ gmail, authorizedScopes });
   const transport = new StdioServerTransport();
   await server.connect(transport);
 }

--- a/src/lazy-boot.test.ts
+++ b/src/lazy-boot.test.ts
@@ -24,15 +24,17 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = __dirname;
 
 describe("lazy-boot tools/list surface", () => {
-  it("source: lazy-boot branch resets authorizedScopes to []", () => {
-    const source = fs.readFileSync(path.join(srcDir, "index.ts"), "utf-8");
-    // After creating the stub OAuth2Client in the lazy-boot path,
-    // authorizedScopes must be set to the empty array so tools/list
-    // returns 0 tools. Guarding both the comment cue and the actual
-    // assignment so a future refactor can't silently drop one.
-    expect(source).toContain("oauth2Client = new OAuth2Client();");
+  it("source: lazy-boot branch returns an empty authorizedScopes set", () => {
+    // The lazy-boot logic now lives in oauth-flow.ts (loadCredentials
+    // returns `{ oauth2Client: new OAuth2Client(), authorizedScopes: [] }`
+    // when `gcp-oauth.keys.json` is absent). Pin both the stub-client
+    // construction AND the empty-scopes return in the same return
+    // statement so a refactor that drops either silently can't pass
+    // both regex matches.
+    const source = fs.readFileSync(path.join(srcDir, "oauth-flow.ts"), "utf-8");
+    expect(source).toContain("new OAuth2Client()");
     expect(source).toMatch(
-      /oauth2Client = new OAuth2Client\(\);[\s\S]{0,1500}authorizedScopes = \[\];/,
+      /oauth2Client: new OAuth2Client\(\),[\s\S]{0,300}authorizedScopes: \[\],/,
     );
   });
 

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -1,0 +1,450 @@
+/**
+ * Unit tests for `loadCredentials` and `authenticate` (`src/oauth-flow.ts`).
+ *
+ * Both helpers were extracted from `src/index.ts` so they can be
+ * exercised without the side-effect of `main()` running on import.
+ * Tests use `tmpdir`-rooted scratch directories + dependency injection
+ * (`exitOnInvalidKeys`, `log`, `openBrowser`) so the real `process.exit`,
+ * `console.error`, and `open` are never touched.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import http from "node:http";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { OAuth2Client } from "google-auth-library";
+import { loadCredentials, authenticate, InvalidOAuthKeysError } from "./oauth-flow.js";
+
+let scratch: string;
+let oauthPath: string;
+let credentialsPath: string;
+let configDir: string;
+let logCapture: string[];
+
+const log = (msg: string, ...rest: unknown[]) => {
+  // Stringify Error objects so `.toContain("EADDRINUSE")` style checks
+  // match the captured representation.
+  logCapture.push(
+    [msg, ...rest.map((x) => (x instanceof Error ? x.message : String(x)))].join(" "),
+  );
+};
+
+beforeEach(() => {
+  scratch = mkdtempSync(join(tmpdir(), "gmail-mcp-oauth-flow-test-"));
+  configDir = join(scratch, ".gmail-mcp");
+  oauthPath = join(configDir, "gcp-oauth.keys.json");
+  credentialsPath = join(configDir, "credentials.json");
+  logCapture = [];
+});
+
+afterEach(() => {
+  rmSync(scratch, { recursive: true, force: true });
+});
+
+describe("loadCredentials", () => {
+  it("returns a stub OAuth2Client + empty scopes when oauthPath does not exist (lazy-boot)", () => {
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: false,
+      log,
+    });
+    expect(result.oauth2Client).toBeInstanceOf(OAuth2Client);
+    expect(result.authorizedScopes).toEqual([]);
+    // No callback URL in lazy-boot mode: no auth flow can run yet.
+    expect(result.oauthCallbackUrl).toBeUndefined();
+    // Should have logged a clear lazy-boot warning (used by hosted MCP
+    // runners' log scrapers to identify a not-yet-authed instance).
+    expect(logCapture.join("\n")).toContain("lazy-auth mode");
+  });
+
+  it("auto-creates the configDir at 0o700 when neither env var is set (skipConfigDirCreate=false)", () => {
+    loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: false,
+      log,
+    });
+    const stats = statSync(configDir);
+    expect(stats.isDirectory()).toBe(true);
+    // POSIX permission bits in lower 9 bits — pin 0o700 to confirm
+    // host-other readers cannot list config files.
+    expect(stats.mode & 0o777).toBe(0o700);
+  });
+
+  it("does NOT create the configDir when skipConfigDirCreate=true and no oauth keys present", () => {
+    // Mirrors `src/index.ts` logic when GMAIL_OAUTH_PATH or
+    // GMAIL_CREDENTIALS_PATH override the default — the operator
+    // pointed elsewhere and may not want a stub ~/.gmail-mcp at $HOME.
+    loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      // Force the local-OAuth check to look at a path that does not
+      // exist either (so we don't fall through to the copy branch
+      // which has its own mkdirSync).
+      localOAuthPath: join(scratch, "no-such-keys.json"),
+      log,
+    });
+    expect(() => statSync(configDir)).toThrow(/ENOENT/);
+  });
+
+  it("loads OAuth keys with `installed` shape and constructs an OAuth2Client", () => {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      oauthPath,
+      JSON.stringify({
+        installed: { client_id: "id-installed", client_secret: "secret-installed" },
+      }),
+    );
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      log,
+    });
+    expect(result.oauth2Client).toBeInstanceOf(OAuth2Client);
+    expect(result.oauthCallbackUrl).toBe("http://localhost:3000/oauth2callback");
+    // No credentials.json yet → DEFAULT_SCOPES carry through.
+    expect(result.authorizedScopes.length).toBeGreaterThan(0);
+  });
+
+  it("loads OAuth keys with the `web` shape (alternate Google Cloud Console export)", () => {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(
+      oauthPath,
+      JSON.stringify({ web: { client_id: "id-web", client_secret: "secret-web" } }),
+    );
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      log,
+    });
+    expect(result.oauth2Client).toBeInstanceOf(OAuth2Client);
+  });
+
+  it("calls exitOnInvalidKeys when the keys file is missing both `installed` and `web`", () => {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, JSON.stringify({ unknown: "shape" }));
+    let exitCode: number | undefined;
+    const exitFn = (code: number): never => {
+      exitCode = code;
+      // Throw a sentinel so loadCredentials' catch block re-throws and
+      // we can `expect(...).toThrow` cleanly. `process.exit` in
+      // production is `(code) => never`, so the catch path never
+      // continues past `exit(1)` either.
+      throw new InvalidOAuthKeysError(oauthPath);
+    };
+    expect(() =>
+      loadCredentials({
+        oauthPath,
+        credentialsPath,
+        configDir,
+        skipConfigDirCreate: true,
+        exitOnInvalidKeys: exitFn,
+        log,
+      }),
+    ).toThrow(InvalidOAuthKeysError);
+    expect(exitCode).toBe(1);
+    expect(logCapture.join("\n")).toContain("Invalid OAuth keys file format");
+  });
+
+  it("uses the new credentials.json shape (`{ tokens, scopes }`) and surfaces the stored scopes", () => {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, JSON.stringify({ installed: { client_id: "x", client_secret: "y" } }));
+    writeFileSync(
+      credentialsPath,
+      JSON.stringify({
+        tokens: { access_token: "at", refresh_token: "rt" },
+        scopes: ["gmail.readonly"],
+      }),
+    );
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      log,
+    });
+    expect(result.authorizedScopes).toEqual(["gmail.readonly"]);
+  });
+
+  it("falls back to DEFAULT_SCOPES when the credentials.json is the legacy flat shape", () => {
+    // Legacy shape from before the v1.2.0 scope-storage rework — bare
+    // OAuth tokens at the root, no `scopes` key. We have to keep
+    // honouring this so users with an existing credentials.json don't
+    // get logged out by an upgrade.
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, JSON.stringify({ installed: { client_id: "x", client_secret: "y" } }));
+    writeFileSync(credentialsPath, JSON.stringify({ access_token: "at", refresh_token: "rt" }));
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      log,
+    });
+    // No `scopes` key → default scope set carries through.
+    expect(result.authorizedScopes.length).toBeGreaterThan(0);
+  });
+
+  it("honours an explicit callbackArg when provided (overrides the localhost:3000 default)", () => {
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, JSON.stringify({ installed: { client_id: "x", client_secret: "y" } }));
+    const result = loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      callbackArg: "http://localhost:9999/cb",
+      log,
+    });
+    expect(result.oauthCallbackUrl).toBe("http://localhost:9999/cb");
+  });
+
+  it("copies a cwd `gcp-oauth.keys.json` to oauthPath at 0o600 and creates the parent dir", () => {
+    const localOAuthPath = join(scratch, "gcp-oauth.keys.json");
+    writeFileSync(
+      localOAuthPath,
+      JSON.stringify({ installed: { client_id: "id-cwd", client_secret: "secret-cwd" } }),
+      { mode: 0o644 },
+    );
+    // configDir does not exist yet — the copy path must mkdir it.
+    loadCredentials({
+      oauthPath,
+      credentialsPath,
+      configDir,
+      // Even when skipConfigDirCreate is true, the copy branch's own
+      // `mkdirSync(path.dirname(oauthPath))` should still fire so the
+      // copy target exists.
+      skipConfigDirCreate: true,
+      localOAuthPath,
+      log,
+    });
+    const stats = statSync(oauthPath);
+    expect(stats.isFile()).toBe(true);
+    // copyFileSync preserves the source mode (0o644 above), so the
+    // explicit chmodSync is what brings it down to 0o600. Pin it.
+    expect(stats.mode & 0o777).toBe(0o600);
+    expect(logCapture.join("\n")).toContain("OAuth keys found in current directory");
+  });
+
+  it("re-throws non-Invalid errors via exitOnInvalidKeys after logging only the message (no Error object)", () => {
+    // A JSON.parse failure on a partial OAuth file — the catch block
+    // must log only the error MESSAGE (not the full Error which can
+    // include a content snippet near `client_secret`).
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, "{ this is not json"); // truncated → SyntaxError
+    let exitCode: number | undefined;
+    const exitFn = (code: number): never => {
+      exitCode = code;
+      throw new Error(`exit-${code}`);
+    };
+    expect(() =>
+      loadCredentials({
+        oauthPath,
+        credentialsPath,
+        configDir,
+        skipConfigDirCreate: true,
+        exitOnInvalidKeys: exitFn,
+        log,
+      }),
+    ).toThrow(/exit-1/);
+    expect(exitCode).toBe(1);
+    const captured = logCapture.join("\n");
+    expect(captured).toContain("Error loading credentials");
+    // Belt-and-braces: confirm the captured log doesn't accidentally
+    // dump a JSON content snippet (e.g. raw file bytes) into stderr —
+    // this would be the regression-trap if a future change replaces
+    // `error.message` with `error` (which on JSON.parse failures
+    // includes a position pointer that may show partial content).
+    expect(captured).not.toContain("this is not json");
+  });
+});
+
+describe("authenticate", () => {
+  /**
+   * Build a hydrated OAuth2Client suitable for authenticate(). We
+   * cannot rely on loadCredentials here because the OAuth2Client's
+   * `redirect_uri` field is part of its private state, so the test
+   * sets it directly with the expected callback URL.
+   */
+  function makeClient(callbackUrl: string): OAuth2Client {
+    return new OAuth2Client("id-test", "secret-test", callbackUrl);
+  }
+
+  it("rejects an https:// callback URL (only loopback http is supported)", async () => {
+    await expect(
+      authenticate({
+        oauth2Client: makeClient("https://localhost:3000/oauth2callback"),
+        oauthCallbackUrl: "https://localhost:3000/oauth2callback",
+        scopes: ["gmail.readonly"],
+        credentialsPath,
+        openBrowser: () => undefined,
+        log,
+      }),
+    ).rejects.toThrow(/Callback protocol 'https:' is not supported/);
+  });
+
+  it("rejects a non-loopback callback hostname", async () => {
+    await expect(
+      authenticate({
+        oauth2Client: makeClient("http://example.com/oauth2callback"),
+        oauthCallbackUrl: "http://example.com/oauth2callback",
+        scopes: ["gmail.readonly"],
+        credentialsPath,
+        openBrowser: () => undefined,
+        log,
+      }),
+    ).rejects.toThrow(/Callback hostname 'example.com' is not loopback/);
+  });
+
+  it("rejects a privileged callback port (port < 1024 requires root)", async () => {
+    // Port 1023 is privileged but URL-parser-friendly (port 80 would
+    // be stripped from `new URL("http://localhost:80/...").port`).
+    await expect(
+      authenticate({
+        oauth2Client: makeClient("http://localhost:1023/oauth2callback"),
+        oauthCallbackUrl: "http://localhost:1023/oauth2callback",
+        scopes: ["gmail.readonly"],
+        credentialsPath,
+        openBrowser: () => undefined,
+        log,
+      }),
+    ).rejects.toThrow(/Callback port '1023' is invalid/);
+  });
+
+  it("rejects port-stripped default ports as the `(default)` placeholder", async () => {
+    // `new URL("http://localhost:80/...")` strips :80 → `parsed.port`
+    // becomes "". The port range check then logs `'(default)'`. Pin
+    // the placeholder so a refactor that switches to `parsed.port` raw
+    // (which would be the empty string) is caught.
+    await expect(
+      authenticate({
+        oauth2Client: makeClient("http://localhost/oauth2callback"),
+        oauthCallbackUrl: "http://localhost/oauth2callback",
+        scopes: ["gmail.readonly"],
+        credentialsPath,
+        openBrowser: () => undefined,
+        log,
+      }),
+    ).rejects.toThrow(/Callback port '\(default\)' is invalid/);
+  });
+
+  it("surfaces EADDRINUSE with a hint when the callback port is already taken", async () => {
+    // Squat on a free port first, then ask authenticate() to listen
+    // on the same port — the listener errors with EADDRINUSE which
+    // the catch turns into a typed rejection with a hint.
+    const squat = http.createServer();
+    await new Promise<void>((res) => squat.listen(0, "127.0.0.1", res));
+    const port = (squat.address() as { port: number }).port;
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    try {
+      await expect(
+        authenticate({
+          oauth2Client: makeClient(cb),
+          oauthCallbackUrl: cb,
+          scopes: ["gmail.readonly"],
+          credentialsPath,
+          openBrowser: () => undefined,
+          log,
+        }),
+      ).rejects.toThrow(
+        /OAuth callback server failed to listen on 127\.0\.0\.1:\d+\..*Another process is already listening/s,
+      );
+    } finally {
+      await new Promise<void>((res) => squat.close(() => res()));
+    }
+  });
+
+  it("rejects when the OAuth callback request omits the `code` query parameter", async () => {
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    // Capture-on-reject pattern: attach the .catch handler
+    // synchronously so the listener-side `reject(new Error("No code
+    // provided"))` always lands on a registered handler. Without
+    // this, vitest can race the rejection against the
+    // `await expect.rejects` and flag it as unhandled.
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: makeClient(cb),
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    // Hit the callback with a missing `code` — this triggers the
+    // `400 No code provided` branch + a reject inside the listener.
+    const res = await fetch(`${cb}?state=foo`);
+    expect(res.status).toBe(400);
+    await settled;
+    expect(caughtErr).toBeInstanceOf(Error);
+    expect(caughtErr?.message).toBe("No code provided");
+  });
+
+  it("writes credentials at 0o600 when the OAuth code exchange succeeds", async () => {
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    const client = makeClient(cb);
+    // Stub the token exchange so we don't hit Google. Because
+    // OAuth2Client.getToken is what `authenticate` calls in the
+    // happy path, replacing it lets us simulate a successful grant.
+    (
+      client as unknown as {
+        getToken: (code: string) => Promise<{ tokens: Record<string, unknown> }>;
+      }
+    ).getToken = async (code: string) => {
+      expect(code).toBe("auth-code-xyz");
+      return Promise.resolve({
+        tokens: { access_token: "at", refresh_token: "rt" },
+      });
+    };
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+
+    const flow = authenticate({
+      oauth2Client: client,
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+    });
+    // Trigger the success branch.
+    const res = await fetch(`${cb}?code=auth-code-xyz`);
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toContain("Authentication successful");
+    await flow;
+
+    const stats = statSync(credentialsPath);
+    expect(stats.mode & 0o777).toBe(0o600);
+    const stored = JSON.parse(readFileSync(credentialsPath, "utf-8")) as {
+      tokens: Record<string, unknown>;
+      scopes: string[];
+    };
+    // Pin both halves of the v1.2.0+ credentials.json shape so a
+    // refactor that drops the scopes key (or that flips back to the
+    // legacy flat shape) is caught.
+    expect(stored.scopes).toEqual(["gmail.readonly"]);
+    expect(stored.tokens).toMatchObject({ access_token: "at", refresh_token: "rt" });
+  });
+});
+
+/** Helper: bind to port 0, capture the OS-assigned port, release. */
+async function pickFreePort(): Promise<number> {
+  const probe = http.createServer();
+  await new Promise<void>((res) => probe.listen(0, "127.0.0.1", res));
+  const port = (probe.address() as { port: number }).port;
+  await new Promise<void>((res) => probe.close(() => res()));
+  return port;
+}

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -10,7 +10,17 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import http from "node:http";
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, statSync, readFileSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  mkdirSync,
+  statSync,
+  readFileSync,
+  openSync,
+  fstatSync,
+  closeSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { OAuth2Client } from "google-auth-library";
@@ -426,12 +436,23 @@ describe("authenticate", () => {
     expect(body).toContain("Authentication successful");
     await flow;
 
-    const stats = statSync(credentialsPath);
-    expect(stats.mode & 0o777).toBe(0o600);
-    const stored = JSON.parse(readFileSync(credentialsPath, "utf-8")) as {
-      tokens: Record<string, unknown>;
-      scopes: string[];
-    };
+    // Open + fstat to pin both the mode AND the bytes against the
+    // SAME open file descriptor. The naive `statSync` then
+    // `readFileSync` shape trips CodeQL's `js/file-system-race`
+    // (TOCTOU between the metadata check and the read); using one
+    // descriptor for both ops eliminates the race window.
+    const fd = openSync(credentialsPath, "r");
+    let stored: { tokens: Record<string, unknown>; scopes: string[] };
+    try {
+      const stats = fstatSync(fd);
+      expect(stats.mode & 0o777).toBe(0o600);
+      stored = JSON.parse(readFileSync(fd, "utf-8")) as {
+        tokens: Record<string, unknown>;
+        scopes: string[];
+      };
+    } finally {
+      closeSync(fd);
+    }
     // Pin both halves of the v1.2.0+ credentials.json shape so a
     // refactor that drops the scopes key (or that flips back to the
     // legacy flat shape) is caught.

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -285,6 +285,39 @@ describe("loadCredentials", () => {
     expect(logCapture.join("\n")).toContain("OAuth keys found in current directory");
   });
 
+  it("does not truncate the keys file when localOAuthPath equals oauthPath (data-loss defence)", () => {
+    // Regression: `fs.copyFileSync(samePath, samePath)` opens the
+    // destination with `O_TRUNC` BEFORE reading the source, which
+    // on POSIX truncates the file to 0 bytes and silently destroys
+    // the OAuth keys. Pins the new same-path guard. Realistic
+    // trigger: `GMAIL_OAUTH_PATH=$(pwd)/gcp-oauth.keys.json`.
+    const samePath = join(scratch, "gcp-oauth.keys.json");
+    const original = JSON.stringify({
+      installed: { client_id: "id-same", client_secret: "secret-same" },
+    });
+    writeFileSync(samePath, original, { mode: 0o600 });
+    const beforeBytes = readFileSync(samePath, "utf-8");
+    expect(beforeBytes).toBe(original);
+
+    const result = loadCredentials({
+      oauthPath: samePath,
+      credentialsPath,
+      configDir,
+      skipConfigDirCreate: true,
+      localOAuthPath: samePath,
+      log,
+    });
+    // File is still on disk and intact — no truncation.
+    const afterBytes = readFileSync(samePath, "utf-8");
+    expect(afterBytes).toBe(original);
+    // The copy log line MUST NOT have been emitted (the no-op
+    // branch fired instead).
+    expect(logCapture.join("\n")).not.toContain("OAuth keys found in current directory");
+    // And the loader still hydrates an OAuth2Client from the
+    // unchanged on-disk keys.
+    expect(result.oauth2Client).toBeInstanceOf(OAuth2Client);
+  });
+
   it("re-throws non-Invalid errors via exitOnInvalidKeys after logging only the message (no Error object)", () => {
     // A JSON.parse failure on a partial OAuth file — the catch block
     // must log only the error MESSAGE (not the full Error which can

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -539,6 +539,116 @@ describe("authenticate", () => {
     expect(stored.scopes).toEqual(["gmail.readonly"]);
     expect(stored.tokens).toMatchObject({ access_token: "at", refresh_token: "rt" });
   });
+
+  it("rejects a multi-byte state without throwing TypeError on Buffer mismatch", async () => {
+    // Defence regression: the previous shape compared
+    // `String.length` (UTF-16 code units) and only later built
+    // Buffers for `crypto.timingSafeEqual` (which requires
+    // identical BYTE lengths). An attacker who supplies a state
+    // with the same code-unit count but multi-byte UTF-8 chars
+    // would have triggered TypeError → unhandled rejection on the
+    // fire-and-forget IIFE → request hangs + listener stays up.
+    // The fix builds both Buffers up front and compares
+    // `.length` (byte length). Pin the no-throw + clean reject
+    // contract on a "café" vs "cafe" pair (4 UTF-16 units, 5 vs 4
+    // bytes).
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    const client = makeClient(cb);
+    let getTokenCalled = false;
+    (
+      client as unknown as {
+        getToken: (code: string) => Promise<{ tokens: Record<string, unknown> }>;
+      }
+    ).getToken = async () => {
+      getTokenCalled = true;
+      return Promise.resolve({ tokens: {} });
+    };
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: client,
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+      generateState: () => "cafe", // 4 ASCII chars, 4 bytes
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    // "café" — 4 UTF-16 code units, but 5 UTF-8 bytes (é = 2 bytes).
+    const res = await fetch(`${cb}?code=anything&state=caf%C3%A9`);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid state");
+    await settled;
+    expect(caughtErr).toBeInstanceOf(Error);
+    expect(caughtErr?.message).toContain("OAuth state mismatch");
+    expect(getTokenCalled).toBe(false);
+  });
+
+  it("logs but does not reject when launchBrowser fails (browser missing)", async () => {
+    // The auth flow prints the authUrl to stderr regardless of
+    // whether `open` can launch a browser, and a missing default
+    // browser must not abort auth — the user can still paste the
+    // URL manually. Pin the .catch handler on the launchBrowser
+    // promise: a thrown launcher logs `Failed to open browser
+    // automatically: ...` and the auth flow continues normally
+    // (here we settle via missing-code to keep the test short).
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: makeClient(cb),
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => {
+        throw new Error("xdg-open not found");
+      },
+      log,
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    // Wait one tick so the listen callback fires and the
+    // launchBrowser .catch handler logs.
+    await new Promise((r) => setTimeout(r, 30));
+    // Settle the auth promise so the test can clean up the
+    // listener — no-code path is the cheapest exit.
+    await fetch(`${cb}`);
+    await settled;
+    expect(caughtErr?.message).toBe("No code provided");
+    expect(logCapture.join("\n")).toContain("Failed to open browser automatically");
+    expect(logCapture.join("\n")).toContain("xdg-open not found");
+  });
+
+  it("rejects with HTTP 500 when the token-exchange call throws", async () => {
+    // After state validation passes, `opts.oauth2Client.getToken(code)`
+    // is awaited inside the try/catch. A network/credentials/quota
+    // error surfaces as a 500 + a typed reject through the catch
+    // arm — pinned here on a synthetic error.
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    const client = makeClient(cb);
+    (client as unknown as { getToken: (code: string) => Promise<unknown> }).getToken = () =>
+      Promise.reject(new Error("invalid_grant"));
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: client,
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+      generateState: () => "deterministic",
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    const res = await fetch(`${cb}?code=anything&state=deterministic`);
+    expect(res.status).toBe(500);
+    expect(await res.text()).toBe("Authentication failed");
+    await settled;
+    expect(caughtErr?.message).toBe("invalid_grant");
+  });
 });
 
 /** Helper: bind to port 0, capture the OS-assigned port, release. */

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -402,6 +402,82 @@ describe("authenticate", () => {
     expect(caughtErr?.message).toBe("No code provided");
   });
 
+  it("rejects when the OAuth state parameter is missing (CSRF defence)", async () => {
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    const client = makeClient(cb);
+    // Spy: if state validation fails, getToken MUST NOT be called.
+    let getTokenCalled = false;
+    (
+      client as unknown as {
+        getToken: (code: string) => Promise<{ tokens: Record<string, unknown> }>;
+      }
+    ).getToken = async () => {
+      getTokenCalled = true;
+      return Promise.resolve({ tokens: {} });
+    };
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: client,
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+      generateState: () => "expected-state-token",
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    // Send a `code` but no `state` — the CSRF guard must refuse
+    // the exchange. Pin the 400 + the typed rejection AND that
+    // `getToken` was never reached.
+    const res = await fetch(`${cb}?code=anything`);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid state");
+    await settled;
+    expect(caughtErr).toBeInstanceOf(Error);
+    expect(caughtErr?.message).toContain("OAuth state mismatch");
+    expect(getTokenCalled).toBe(false);
+  });
+
+  it("rejects when the OAuth state parameter does not match the expected value", async () => {
+    const port = await pickFreePort();
+    const cb = `http://127.0.0.1:${port}/oauth2callback`;
+    const client = makeClient(cb);
+    let getTokenCalled = false;
+    (
+      client as unknown as {
+        getToken: (code: string) => Promise<{ tokens: Record<string, unknown> }>;
+      }
+    ).getToken = async () => {
+      getTokenCalled = true;
+      return Promise.resolve({ tokens: {} });
+    };
+    let caughtErr: Error | undefined;
+    const settled = authenticate({
+      oauth2Client: client,
+      oauthCallbackUrl: cb,
+      scopes: ["gmail.readonly"],
+      credentialsPath,
+      openBrowser: () => undefined,
+      log,
+      generateState: () => "expected-state-token",
+    }).catch((err: unknown) => {
+      caughtErr = err instanceof Error ? err : new Error(String(err));
+    });
+    // Wrong state — same length and a non-trivial mismatch so the
+    // length-fast-path doesn't short-circuit the timing-safe
+    // comparison. Pin the same 400 + reject + getToken-not-called
+    // contract as the missing-state case above.
+    const res = await fetch(`${cb}?code=anything&state=attacker-state-value`);
+    expect(res.status).toBe(400);
+    expect(await res.text()).toBe("Invalid state");
+    await settled;
+    expect(caughtErr).toBeInstanceOf(Error);
+    expect(caughtErr?.message).toContain("OAuth state mismatch");
+    expect(getTokenCalled).toBe(false);
+  });
+
   it("writes credentials at 0o600 when the OAuth code exchange succeeds", async () => {
     const port = await pickFreePort();
     const cb = `http://127.0.0.1:${port}/oauth2callback`;
@@ -428,9 +504,13 @@ describe("authenticate", () => {
       credentialsPath,
       openBrowser: () => undefined,
       log,
+      // Pin a deterministic state so the success-fetch can supply
+      // the matching `?state=…`. Production uses
+      // `crypto.randomBytes(32).toString("base64url")`.
+      generateState: () => "test-state-deterministic",
     });
-    // Trigger the success branch.
-    const res = await fetch(`${cb}?code=auth-code-xyz`);
+    // Trigger the success branch — must include the matching state.
+    const res = await fetch(`${cb}?code=auth-code-xyz&state=test-state-deterministic`);
     expect(res.status).toBe(200);
     const body = await res.text();
     expect(body).toContain("Authentication successful");

--- a/src/oauth-flow.test.ts
+++ b/src/oauth-flow.test.ts
@@ -166,6 +166,45 @@ describe("loadCredentials", () => {
     expect(logCapture.join("\n")).toContain("Invalid OAuth keys file format");
   });
 
+  it.each([
+    ["empty installed object", { installed: {} }],
+    ["installed missing client_secret", { installed: { client_id: "x" } }],
+    ["installed missing client_id", { installed: { client_secret: "y" } }],
+    ["installed empty-string client_id", { installed: { client_id: "", client_secret: "y" } }],
+    ["installed empty-string client_secret", { installed: { client_id: "x", client_secret: "" } }],
+    ["web missing client_secret", { web: { client_id: "x" } }],
+  ] as const)("rejects partial OAuth key shapes up-front: %s", (_label, payload) => {
+    // CR Major: `{ installed: {} }` and friends previously passed
+    // the truthy `installed || web` check and produced an
+    // OAuth2Client with `undefined` credentials, deferring the
+    // failure to the first `getToken(...)` call. Pin that the
+    // up-front validator now rejects every partial shape with
+    // the existing invalid-keys path so the operator sees the
+    // configuration root cause at boot.
+    mkdirSync(configDir, { recursive: true, mode: 0o700 });
+    writeFileSync(oauthPath, JSON.stringify(payload));
+    let exitCode: number | undefined;
+    const exitFn = (code: number): never => {
+      exitCode = code;
+      throw new InvalidOAuthKeysError(oauthPath);
+    };
+    expect(() =>
+      loadCredentials({
+        oauthPath,
+        credentialsPath,
+        configDir,
+        skipConfigDirCreate: true,
+        exitOnInvalidKeys: exitFn,
+        log,
+      }),
+    ).toThrow(InvalidOAuthKeysError);
+    expect(exitCode).toBe(1);
+    // The new message names the missing fields so a sysadmin
+    // copy-pasting the wrong export (e.g. only the public id)
+    // sees what to fix.
+    expect(logCapture.join("\n")).toContain("non-empty client_id and client_secret values");
+  });
+
   it("uses the new credentials.json shape (`{ tokens, scopes }`) and surfaces the stored scopes", () => {
     mkdirSync(configDir, { recursive: true, mode: 0o700 });
     writeFileSync(oauthPath, JSON.stringify({ installed: { client_id: "x", client_secret: "y" } }));

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -1,0 +1,346 @@
+/**
+ * OAuth flow for the Gmail MCP server.
+ *
+ * Two responsibilities, both extracted from `src/index.ts` so they
+ * can be unit-tested without spinning the whole MCP entry point
+ * (which calls `main()` on module load):
+ *
+ *   - `loadCredentials({ oauthPath, credentialsPath, configDir, ...})`
+ *     reads (or stubs) the OAuth keys + stored credentials from disk
+ *     and returns a hydrated `OAuth2Client` plus the authorised
+ *     scope set. Pure — returns a value instead of mutating
+ *     module-level `let` bindings.
+ *
+ *   - `authenticate({ oauth2Client, oauthCallbackUrl, scopes,
+ *     credentialsPath })` runs the interactive browser-based OAuth
+ *     callback flow and writes the resulting tokens to
+ *     `credentialsPath`.
+ *
+ * The mutations to module-level state previously living in
+ * `src/index.ts` are gone; `index.ts` now wires the return value
+ * of `loadCredentials` straight into `createServer({ oauth2Client,
+ * authorizedScopes })`. Testability and lazy-boot semantics are
+ * preserved bit-for-bit.
+ */
+
+import fs from "fs";
+import path from "path";
+import http from "http";
+import open from "open";
+import { OAuth2Client } from "google-auth-library";
+import { DEFAULT_SCOPES, scopeNamesToUrls } from "./scopes.js";
+
+export interface LoadCredentialsOpts {
+  /** Path to the OAuth keys JSON (`gcp-oauth.keys.json` shape). */
+  oauthPath: string;
+  /** Path to the stored credentials JSON (`credentials.json` shape). */
+  credentialsPath: string;
+  /** Config dir to create at `0o700` if it doesn't exist. */
+  configDir: string;
+  /**
+   * Whether to skip the `mkdirSync(configDir)` step when env vars
+   * point at custom paths outside the default `~/.gmail-mcp` tree.
+   * `src/index.ts` honours `GMAIL_OAUTH_PATH` / `GMAIL_CREDENTIALS_PATH`
+   * — when either is set, the default `~/.gmail-mcp` directory must
+   * not be auto-created.
+   */
+  skipConfigDirCreate: boolean;
+  /**
+   * Optional positional CLI arg holding the callback URL for the
+   * `auth` flow (`http://localhost:8080/oauth2callback` etc.). When
+   * absent, defaults to `http://localhost:3000/oauth2callback`.
+   */
+  callbackArg?: string;
+  /**
+   * Optional path to a `gcp-oauth.keys.json` in the current working
+   * directory. When present, it is copied to `oauthPath` at `0o600`
+   * before the lookup. Defaults to `path.join(process.cwd(),
+   * "gcp-oauth.keys.json")`.
+   */
+  localOAuthPath?: string;
+  /**
+   * Process-exit hook (defaults to `process.exit`). Lets tests
+   * replace the hard exit on invalid OAuth keys with a thrown
+   * sentinel so the test process is not killed.
+   */
+  exitOnInvalidKeys?: (code: number) => never;
+  /**
+   * stderr writer (defaults to `console.error`). Lets tests capture
+   * the lazy-boot warning + the "OAuth keys copied" notice without
+   * polluting test output.
+   */
+  log?: (msg: string, ...rest: unknown[]) => void;
+}
+
+export interface LoadCredentialsResult {
+  oauth2Client: OAuth2Client;
+  /**
+   * The authorised scope set carried by the stored token (if any).
+   * Empty `[]` when no OAuth keys were found at all (lazy-boot mode);
+   * `DEFAULT_SCOPES` when keys are present but no `credentials.json`
+   * has been written yet (i.e. before the first `auth` run).
+   */
+  authorizedScopes: readonly string[];
+  /**
+   * The OAuth callback URL the `authenticate` step should bind to.
+   * `undefined` in lazy-boot mode (no `auth` is going to run yet).
+   */
+  oauthCallbackUrl?: string;
+}
+
+/**
+ * Sentinel thrown when the OAuth keys file is present but malformed
+ * (missing `installed` AND `web` properties). The legacy code called
+ * `process.exit(1)` here; the new shape lets the caller decide
+ * whether to exit or surface the error elsewhere.
+ */
+export class InvalidOAuthKeysError extends Error {
+  constructor(public readonly keysPath: string) {
+    super(
+      `Invalid OAuth keys file format at ${keysPath}. File should contain either "installed" or "web" credentials.`,
+    );
+    this.name = "InvalidOAuthKeysError";
+  }
+}
+
+export function loadCredentials(opts: LoadCredentialsOpts): LoadCredentialsResult {
+  const log = opts.log ?? ((msg: string, ...rest: unknown[]) => console.error(msg, ...rest));
+  const exit = opts.exitOnInvalidKeys ?? ((code: number) => process.exit(code));
+
+  try {
+    if (!opts.skipConfigDirCreate && !fs.existsSync(opts.configDir)) {
+      fs.mkdirSync(opts.configDir, { recursive: true, mode: 0o700 });
+    }
+
+    const localOAuthPath = opts.localOAuthPath ?? path.join(process.cwd(), "gcp-oauth.keys.json");
+
+    if (fs.existsSync(localOAuthPath)) {
+      // Copy from cwd to the global config. The `mkdir` here covers
+      // the case where `skipConfigDirCreate` is true because only
+      // `GMAIL_CREDENTIALS_PATH` was overridden — `OAUTH_PATH` still
+      // defaults under `~/.gmail-mcp` and would ENOENT without
+      // explicit mkdir. Also force `0o600`: `copyFileSync` preserves
+      // the source mode, so a `0o644` cwd file would keep that mode.
+      fs.mkdirSync(path.dirname(opts.oauthPath), { recursive: true, mode: 0o700 });
+      fs.copyFileSync(localOAuthPath, opts.oauthPath);
+      fs.chmodSync(opts.oauthPath, 0o600);
+      log("OAuth keys found in current directory, copied to global config.");
+    }
+
+    if (!fs.existsSync(opts.oauthPath)) {
+      // Lazy-boot mode: no OAuth keys at startup. Hosted MCP runners
+      // (Glama, Smithery, etc.) run a smoke test on `tools/list`
+      // before the user has any chance to mount credentials, and
+      // exiting here would mark the server as broken on the
+      // registry. Boot with a stub `OAuth2Client` instead — the
+      // factory's `tools/list` (which does not touch
+      // `gmail.users.*`) succeeds, and any tool call that needs
+      // auth fails cleanly through the `asGmailApiError` path with
+      // an `INVALID_GRANT`-shaped payload.
+      log(
+        `Warning: OAuth keys file not found at ${opts.oauthPath} — booting in lazy-auth mode. Tool calls that need Gmail will fail until \`npx @klodr/gmail-mcp auth\` is run.`,
+      );
+      // Empty `authorizedScopes` narrows the advertised tool surface
+      // to `[]` until credentials are mounted — none of the 26 Gmail
+      // tools can succeed without an authorised scope.
+      return {
+        oauth2Client: new OAuth2Client(),
+        authorizedScopes: [],
+      };
+    }
+
+    const keysContent = JSON.parse(fs.readFileSync(opts.oauthPath, "utf8")) as {
+      installed?: { client_id?: string; client_secret?: string };
+      web?: { client_id?: string; client_secret?: string };
+    };
+    const keys = keysContent.installed || keysContent.web;
+
+    if (!keys) {
+      log(
+        `Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.`,
+      );
+      // Default behaviour matches the legacy dispatcher: hard exit
+      // so the operator notices a malformed file at boot. Tests
+      // override `exitOnInvalidKeys` to throw an
+      // `InvalidOAuthKeysError` instead.
+      exit(1);
+      // `exit` is `(code: number) => never`; the throw below is dead
+      // code at runtime but lets the type-checker know the function
+      // does not fall through into the next statement.
+      throw new InvalidOAuthKeysError(opts.oauthPath);
+    }
+
+    const oauthCallbackUrl = opts.callbackArg ?? "http://localhost:3000/oauth2callback";
+    const oauth2Client = new OAuth2Client(keys.client_id, keys.client_secret, oauthCallbackUrl);
+
+    let authorizedScopes: readonly string[] = DEFAULT_SCOPES;
+
+    if (fs.existsSync(opts.credentialsPath)) {
+      const credentials = JSON.parse(fs.readFileSync(opts.credentialsPath, "utf8")) as {
+        tokens?: Record<string, unknown>;
+        scopes?: string[];
+        [key: string]: unknown;
+      };
+
+      // Credentials file structure (v1.2.0+):
+      //   { "tokens": { access_token, refresh_token, ... }, "scopes": [...] }
+      // Legacy structure (pre-v1.2.0):
+      //   { access_token, refresh_token, ... }
+      // We support both formats for backwards compatibility. Users
+      // with legacy credentials get DEFAULT_SCOPES (full access)
+      // until they re-authenticate.
+      const tokens = credentials.tokens ?? credentials;
+      oauth2Client.setCredentials(tokens);
+
+      if (credentials.scopes) {
+        authorizedScopes = credentials.scopes;
+      }
+    }
+
+    return { oauth2Client, oauthCallbackUrl, authorizedScopes };
+  } catch (error) {
+    if (error instanceof InvalidOAuthKeysError) {
+      throw error;
+    }
+    // Log only the error message, not the full Error object — a
+    // JSON.parse failure on a partially-corrupted OAuth file carries
+    // a snippet of the faulty content (position/line pointer) that
+    // could include `client_secret` if the corruption landed near
+    // it. Stderr is forwarded to the MCP host's logs.
+    const msg = error instanceof Error ? error.message : String(error);
+    log(`Error loading credentials: ${msg}`);
+    exit(1);
+    throw error;
+  }
+}
+
+export interface AuthenticateOpts {
+  oauth2Client: OAuth2Client;
+  oauthCallbackUrl: string;
+  scopes: string[];
+  credentialsPath: string;
+  /**
+   * Process-launch hook (defaults to `open(authUrl)`). Lets tests
+   * skip the actual browser launch.
+   */
+  openBrowser?: (url: string) => unknown;
+  log?: (msg: string, ...rest: unknown[]) => void;
+}
+
+export async function authenticate(opts: AuthenticateOpts): Promise<void> {
+  const log = opts.log ?? ((msg: string, ...rest: unknown[]) => console.error(msg, ...rest));
+  const launchBrowser = opts.openBrowser ?? open;
+
+  const parsed = new URL(opts.oauthCallbackUrl);
+
+  // The built-in callback listener is plain `http.createServer`. If
+  // the caller passes an `https://` URL, OAuth would redirect to a
+  // TLS target that nothing on this process is listening on —
+  // silent failure.
+  if (parsed.protocol !== "http:") {
+    throw new Error(
+      `Callback protocol '${parsed.protocol}' is not supported. ` +
+        `The built-in auth server only accepts loopback HTTP callbacks (http://localhost...).`,
+    );
+  }
+
+  const hostname = parsed.hostname;
+  const isLoopback = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+
+  if (!isLoopback) {
+    throw new Error(
+      `Callback hostname '${hostname}' is not loopback. ` +
+        `Only http://localhost / 127.0.0.1 / [::1] are supported by the built-in ` +
+        `auth flow. Either (a) rerun 'auth' without a positional callback URL, ` +
+        `or (b) point your Web OAuth client at a loopback URL.`,
+    );
+  }
+
+  const port = parsed.port ? Number(parsed.port) : 80;
+  // Range-check the callback port up-front. The built-in auth
+  // server is a non-privileged loopback listener — privileged ports
+  // (1-1023) require root and are almost certainly a misconfig;
+  // ports outside 1-65535 are not valid TCP at all.
+  if (!Number.isInteger(port) || port < 1024 || port > 65535) {
+    throw new Error(
+      `Callback port '${parsed.port || "(default)"}' is invalid. ` +
+        `The built-in auth server requires an unprivileged TCP port (1024-65535). ` +
+        `Pick a free port in that range and pass it via the callback URL.`,
+    );
+  }
+  const callbackPath = parsed.pathname || "/oauth2callback";
+
+  const httpServer = http.createServer();
+  const scopeUrls = scopeNamesToUrls(opts.scopes);
+
+  return new Promise<void>((resolve, reject) => {
+    httpServer.on("error", (err: NodeJS.ErrnoException) => {
+      const hint =
+        err.code === "EADDRINUSE"
+          ? ` Another process is already listening on that port — pick a different one or stop the conflicting process.`
+          : err.code === "EACCES"
+            ? ` Insufficient privilege to bind that port — pick a port >= 1024.`
+            : "";
+      reject(
+        new Error(`OAuth callback server failed to listen on ${hostname}:${port}.${hint}`, {
+          cause: err,
+        }),
+      );
+    });
+    httpServer.listen(port, hostname);
+
+    const authUrl = opts.oauth2Client.generateAuthUrl({
+      access_type: "offline",
+      scope: scopeUrls,
+    });
+
+    log("Requesting scopes:", opts.scopes.join(", "));
+    log("Please visit this URL to authenticate:", authUrl);
+    void launchBrowser(authUrl);
+
+    const hostForUrl = hostname.includes(":") ? `[${hostname}]` : hostname;
+    const baseUrl = `http://${hostForUrl}:${port}`;
+
+    httpServer.on("request", (req, res) => {
+      void (async () => {
+        if (!req.url) return;
+
+        const url = new URL(req.url, baseUrl);
+        if (url.pathname !== callbackPath) return;
+
+        const code = url.searchParams.get("code");
+
+        if (!code) {
+          res.writeHead(400);
+          res.end("No code provided");
+          reject(new Error("No code provided"));
+          return;
+        }
+
+        try {
+          const { tokens } = await opts.oauth2Client.getToken(code);
+          opts.oauth2Client.setCredentials(tokens);
+
+          // writeFileSync's `mode` only applies on CREATE; force
+          // `0o600` after to match `.github/SECURITY.md`.
+          const credentials = { tokens, scopes: opts.scopes };
+          fs.mkdirSync(path.dirname(opts.credentialsPath), { recursive: true, mode: 0o700 });
+          fs.writeFileSync(opts.credentialsPath, JSON.stringify(credentials, null, 2), {
+            mode: 0o600,
+          });
+          fs.chmodSync(opts.credentialsPath, 0o600);
+
+          res.writeHead(200);
+          res.end("Authentication successful! You can close this window.");
+          log("Credentials saved with scopes:", opts.scopes.join(", "));
+          httpServer.close();
+          resolve();
+        } catch (error) {
+          res.writeHead(500);
+          res.end("Authentication failed");
+          reject(error instanceof Error ? error : new Error(String(error)));
+        }
+      })();
+    });
+  });
+}

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -156,9 +156,24 @@ export function loadCredentials(opts: LoadCredentialsOpts): LoadCredentialsResul
     };
     const keys = keysContent.installed || keysContent.web;
 
-    if (!keys) {
+    // Partial-keys defence (CR Major): `{ installed: {} }` or
+    // `{ web: { client_id: "x" } }` (no client_secret) currently
+    // passes the truthy `installed || web` check and produces an
+    // `OAuth2Client` with `undefined` credentials. That defers the
+    // failure to the first `getToken(...)` call (where the error
+    // surfaces as a Google `invalid_client` token-exchange
+    // rejection, far from the boot configuration root cause).
+    // Fail at boot with the existing invalid-keys path instead so
+    // the operator sees the real diagnostic.
+    if (
+      !keys ||
+      typeof keys.client_id !== "string" ||
+      keys.client_id.length === 0 ||
+      typeof keys.client_secret !== "string" ||
+      keys.client_secret.length === 0
+    ) {
       log(
-        `Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials.`,
+        `Error: Invalid OAuth keys file format. File should contain either "installed" or "web" credentials with non-empty client_id and client_secret values.`,
       );
       // Default behaviour matches the legacy dispatcher: hard exit
       // so the operator notices a malformed file at boot. Tests

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -324,10 +324,20 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
 
       log("Requesting scopes:", opts.scopes.join(", "));
       log("Please visit this URL to authenticate:", authUrl);
-      void Promise.resolve(launchBrowser(authUrl)).catch((err: unknown) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        log(`Failed to open browser automatically: ${msg}`);
-      });
+      // `Promise.resolve().then(...)` (instead of
+      // `Promise.resolve(launchBrowser(authUrl))`) so a SYNC throw
+      // from the launcher (e.g. `xdg-open` not on PATH on a
+      // headless box, or `open` rejecting a malformed URL before
+      // returning the Promise) is also caught — the bare
+      // `Promise.resolve(throwing-call)` shape lets sync throws
+      // escape the `.catch` chain, which would crash the auth flow
+      // for what should be a non-fatal "no default browser" event.
+      void Promise.resolve()
+        .then(() => launchBrowser(authUrl))
+        .catch((err: unknown) => {
+          const msg = err instanceof Error ? err.message : String(err);
+          log(`Failed to open browser automatically: ${msg}`);
+        });
     });
 
     const hostForUrl = hostname.includes(":") ? `[${hostname}]` : hostname;
@@ -370,13 +380,21 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
         // callback was not initiated by this flow — refuse the
         // grant rather than potentially binding the user to an
         // attacker-controlled Google account.
+        //
+        // Compare BYTE lengths, not String.length (UTF-16 code-unit
+        // count). An attacker who supplies a multi-byte UTF-8 state
+        // with a String.length matching `expectedState` would
+        // otherwise reach `timingSafeEqual` with mismatched-byte
+        // Buffers, which throws TypeError → unhandled rejection on
+        // the fire-and-forget IIFE → request hangs + listener stays
+        // up. Fix: build both Buffers up front and compare their
+        // `.length` (which is byte length, not UTF-16 units).
+        const expectedBuf = Buffer.from(expectedState, "utf-8");
+        const stateBuf = stateParam === null ? null : Buffer.from(stateParam, "utf-8");
         if (
-          stateParam === null ||
-          stateParam.length !== expectedState.length ||
-          !crypto.timingSafeEqual(
-            Buffer.from(stateParam, "utf-8"),
-            Buffer.from(expectedState, "utf-8"),
-          )
+          stateBuf === null ||
+          stateBuf.length !== expectedBuf.length ||
+          !crypto.timingSafeEqual(stateBuf, expectedBuf)
         ) {
           res.writeHead(400);
           res.end("Invalid state");

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -26,6 +26,7 @@
 import fs from "fs";
 import path from "path";
 import http from "http";
+import crypto from "crypto";
 import open from "open";
 import { OAuth2Client } from "google-auth-library";
 import { DEFAULT_SCOPES, scopeNamesToUrls } from "./scopes.js";
@@ -225,6 +226,14 @@ export interface AuthenticateOpts {
    */
   openBrowser?: (url: string) => unknown;
   log?: (msg: string, ...rest: unknown[]) => void;
+  /**
+   * Per-flow OAuth `state` generator (defaults to
+   * `crypto.randomBytes(32).toString("base64url")`). Lets tests pin
+   * a deterministic value so the fetch in the callback can supply
+   * the matching `?state=…` parameter without first having to read
+   * the URL the server printed to stderr.
+   */
+  generateState?: () => string;
 }
 
 export async function authenticate(opts: AuthenticateOpts): Promise<void> {
@@ -273,6 +282,16 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
   const httpServer = http.createServer();
   const scopeUrls = scopeNamesToUrls(opts.scopes);
 
+  // Per-flow OAuth `state` (RFC 6749 §10.12 — login-CSRF defence).
+  // 256-bit random value, base64url-encoded. Without this, an
+  // attacker who tricks the user into clicking
+  // `http://localhost:<port>/oauth2callback?code=ATTACKER_CODE`
+  // during the auth window can swap the user's flow for theirs
+  // (the user ends up authenticated against the attacker's Google
+  // account). Tests inject a deterministic generator so the
+  // callback fetch can supply the matching `?state=…`.
+  const expectedState = opts.generateState?.() ?? crypto.randomBytes(32).toString("base64url");
+
   return new Promise<void>((resolve, reject) => {
     httpServer.on("error", (err: NodeJS.ErrnoException) => {
       const hint =
@@ -300,6 +319,7 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
       const authUrl = opts.oauth2Client.generateAuthUrl({
         access_type: "offline",
         scope: scopeUrls,
+        state: expectedState,
       });
 
       log("Requesting scopes:", opts.scopes.join(", "));
@@ -321,6 +341,7 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
         if (url.pathname !== callbackPath) return;
 
         const code = url.searchParams.get("code");
+        const stateParam = url.searchParams.get("state");
 
         // Settle the auth promise only after the http server is
         // fully closed: stop accepting new connections AND tear
@@ -341,6 +362,31 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
           // cannot keep executing the handler against an
           // already-settled promise.
           finalize(() => reject(new Error("No code provided")));
+          return;
+        }
+
+        // Validate the OAuth `state` round-trip BEFORE exchanging
+        // the code. A missing or mismatched state means the
+        // callback was not initiated by this flow — refuse the
+        // grant rather than potentially binding the user to an
+        // attacker-controlled Google account.
+        if (
+          stateParam === null ||
+          stateParam.length !== expectedState.length ||
+          !crypto.timingSafeEqual(
+            Buffer.from(stateParam, "utf-8"),
+            Buffer.from(expectedState, "utf-8"),
+          )
+        ) {
+          res.writeHead(400);
+          res.end("Invalid state");
+          finalize(() =>
+            reject(
+              new Error(
+                "OAuth state mismatch: refusing to exchange the authorization code. The callback may have been initiated by a different OAuth flow.",
+              ),
+            ),
+          );
           return;
         }
 

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -287,16 +287,28 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
         }),
       );
     });
-    httpServer.listen(port, hostname);
+    // Defer the auth-URL build + browser launch into the listen
+    // callback so they run only after the server is actually bound.
+    // CR Major: kicking the browser before listen() is bound is a
+    // race — the user could click through to the callback URL on a
+    // port that hasn't started listening yet, and the redirect
+    // would 404 silently. The catch on `launchBrowser` swallows the
+    // browser process's exit code (a missing default browser is
+    // not a fatal auth-flow failure — the URL is also printed to
+    // stderr above so the user can paste it manually).
+    httpServer.listen(port, hostname, () => {
+      const authUrl = opts.oauth2Client.generateAuthUrl({
+        access_type: "offline",
+        scope: scopeUrls,
+      });
 
-    const authUrl = opts.oauth2Client.generateAuthUrl({
-      access_type: "offline",
-      scope: scopeUrls,
+      log("Requesting scopes:", opts.scopes.join(", "));
+      log("Please visit this URL to authenticate:", authUrl);
+      void Promise.resolve(launchBrowser(authUrl)).catch((err: unknown) => {
+        const msg = err instanceof Error ? err.message : String(err);
+        log(`Failed to open browser automatically: ${msg}`);
+      });
     });
-
-    log("Requesting scopes:", opts.scopes.join(", "));
-    log("Please visit this URL to authenticate:", authUrl);
-    void launchBrowser(authUrl);
 
     const hostForUrl = hostname.includes(":") ? `[${hostname}]` : hostname;
     const baseUrl = `http://${hostForUrl}:${port}`;
@@ -310,10 +322,25 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
 
         const code = url.searchParams.get("code");
 
+        // Settle the auth promise only after the http server is
+        // fully closed: stop accepting new connections AND tear
+        // down keepalive sockets so the port is released
+        // immediately. Without `closeAllConnections`, a fetch
+        // client holding the connection open keeps `close()`'s
+        // callback hanging and the promise never settles.
+        const finalize = (settle: () => void): void => {
+          httpServer.close(() => settle());
+          httpServer.closeAllConnections?.();
+        };
+
         if (!code) {
           res.writeHead(400);
           res.end("No code provided");
-          reject(new Error("No code provided"));
+          // CR Major: close the listener before rejecting so the
+          // port is released and a subsequent drive-by request
+          // cannot keep executing the handler against an
+          // already-settled promise.
+          finalize(() => reject(new Error("No code provided")));
           return;
         }
 
@@ -333,12 +360,19 @@ export async function authenticate(opts: AuthenticateOpts): Promise<void> {
           res.writeHead(200);
           res.end("Authentication successful! You can close this window.");
           log("Credentials saved with scopes:", opts.scopes.join(", "));
-          httpServer.close();
-          resolve();
+          // Resolve only AFTER the server has actually closed so
+          // the caller's `await authenticate(...)` does not race
+          // with a still-bound listener (symmetric with the error
+          // paths below).
+          finalize(resolve);
         } catch (error) {
           res.writeHead(500);
           res.end("Authentication failed");
-          reject(error instanceof Error ? error : new Error(String(error)));
+          // CR Major: same as the missing-code branch — close the
+          // listener before rejecting so the port is released and
+          // a subsequent request cannot keep firing against the
+          // settled promise.
+          finalize(() => reject(error instanceof Error ? error : new Error(String(error))));
         }
       })();
     });

--- a/src/oauth-flow.ts
+++ b/src/oauth-flow.ts
@@ -116,16 +116,45 @@ export function loadCredentials(opts: LoadCredentialsOpts): LoadCredentialsResul
     const localOAuthPath = opts.localOAuthPath ?? path.join(process.cwd(), "gcp-oauth.keys.json");
 
     if (fs.existsSync(localOAuthPath)) {
-      // Copy from cwd to the global config. The `mkdir` here covers
-      // the case where `skipConfigDirCreate` is true because only
-      // `GMAIL_CREDENTIALS_PATH` was overridden — `OAUTH_PATH` still
-      // defaults under `~/.gmail-mcp` and would ENOENT without
-      // explicit mkdir. Also force `0o600`: `copyFileSync` preserves
-      // the source mode, so a `0o644` cwd file would keep that mode.
-      fs.mkdirSync(path.dirname(opts.oauthPath), { recursive: true, mode: 0o700 });
-      fs.copyFileSync(localOAuthPath, opts.oauthPath);
-      fs.chmodSync(opts.oauthPath, 0o600);
-      log("OAuth keys found in current directory, copied to global config.");
+      // Skip the copy when source and destination are the same
+      // file — e.g. `GMAIL_OAUTH_PATH=$(pwd)/gcp-oauth.keys.json`
+      // (the cwd file IS the configured path), or the default
+      // resolution lands on the same realpath. Without this guard
+      // `fs.copyFileSync` opens the destination with `O_TRUNC`
+      // BEFORE reading the source, which on POSIX truncates the
+      // file to 0 bytes and silently destroys the OAuth keys.
+      // Compare absolute paths up-front; fall back to
+      // `realpathSync` on the destination only if it exists (it
+      // may not — that's the whole point of the copy).
+      const srcAbs = path.resolve(localOAuthPath);
+      const dstAbs = path.resolve(opts.oauthPath);
+      const sameByPath = srcAbs === dstAbs;
+      let sameByRealpath = false;
+      if (!sameByPath && fs.existsSync(opts.oauthPath)) {
+        try {
+          sameByRealpath = fs.realpathSync(srcAbs) === fs.realpathSync(dstAbs);
+        } catch {
+          // realpath failure (broken symlink, EACCES) — fall through
+          // to the copy. Worst case: the existing file gets
+          // overwritten with itself, but that's safe via two
+          // different inodes.
+        }
+      }
+      if (sameByPath || sameByRealpath) {
+        // No-op: source == destination already.
+      } else {
+        // Copy from cwd to the global config. The `mkdir` here
+        // covers the case where `skipConfigDirCreate` is true
+        // because only `GMAIL_CREDENTIALS_PATH` was overridden —
+        // `OAUTH_PATH` still defaults under `~/.gmail-mcp` and
+        // would ENOENT without explicit mkdir. Also force `0o600`:
+        // `copyFileSync` preserves the source mode, so a `0o644`
+        // cwd file would keep that mode.
+        fs.mkdirSync(path.dirname(opts.oauthPath), { recursive: true, mode: 0o700 });
+        fs.copyFileSync(localOAuthPath, opts.oauthPath);
+        fs.chmodSync(opts.oauthPath, 0o600);
+        log("OAuth keys found in current directory, copied to global config.");
+      }
     }
 
     if (!fs.existsSync(opts.oauthPath)) {


### PR DESCRIPTION
## Summary

Extract `loadCredentials()` and `authenticate()` from `src/index.ts`
into a new `src/oauth-flow.ts` module so both can be unit-tested
without booting the full MCP entry point. The previous shape
mutated module-level `let` bindings (`oauth2Client`,
`oauthCallbackUrl`, `authorizedScopes`); the new shape returns a
plain value (`{ oauth2Client, authorizedScopes, oauthCallbackUrl? }`)
and accepts dependency-injection points (`exitOnInvalidKeys`,
`log`, `openBrowser`, `localOAuthPath`) so tests don't fire
`process.exit`, write to `console.error`, launch a browser, or
look at the test runner's cwd.

## Changes

- `src/oauth-flow.ts` (new, 346 LOC) — `loadCredentials` +
  `authenticate` + `InvalidOAuthKeysError` sentinel
- `src/oauth-flow.test.ts` (new, 18 cases, ~92% statement coverage on
  the new file)
- `src/index.ts` — shrinks from 376 → ~157 LOC. What remains is
  bootstrap glue: argv parsing, `GMAIL_MCP_TIMEOUT_MS`, the
  `getAccessToken` startup probe, and the `createServer` +
  `transport.connect` handoff
- `src/lazy-boot.test.ts` — source-pin test now greps `oauth-flow.ts`
  (where the lazy-boot logic now lives) instead of `index.ts`
- `codecov.yml` — comment updated to reflect that the testable OAuth
  flow now lives in `oauth-flow.ts`. `src/index.ts` stays in
  `ignore` for now (what's left there is bootstrap glue not
  reachable without invoking `main()`)

## Behaviour

No behaviour change. The lazy-boot path still:
- builds a stub `OAuth2Client` when `gcp-oauth.keys.json` is absent
- returns an empty `authorizedScopes` so `tools/list` advertises 0
  tools until the first `auth` run
- preserves the cwd-keys-copy → `0o600` chmod path
- preserves the auto-create of `~/.gmail-mcp` at `0o700` (skipped
  when `GMAIL_OAUTH_PATH` or `GMAIL_CREDENTIALS_PATH` overrides
  the default)
- preserves the `Error loading credentials: <message>` log shape
  that strips the full Error object so a JSON.parse failure cannot
  leak a content snippet near `client_secret` to stderr

## New test coverage

`src/oauth-flow.test.ts` (18 cases):

**`loadCredentials`** — lazy-boot stub return, configDir auto-create
at 0o700, skip-create when env vars override, `installed` keys
shape, `web` keys shape, invalid-keys via injected `exit`, v1.2.0+
credentials.json shape, legacy flat credentials shape, explicit
`callbackArg` override, cwd-keys-copy + 0o600 chmod, JSON.parse
failure logs only the message (no Error object → no
content-snippet leak near `client_secret`).

**`authenticate`** — rejects `https://`, rejects non-loopback
hostname, rejects port < 1024, rejects port-stripped default port,
surfaces EADDRINUSE with hint, rejects on missing `code` query
param, writes credentials at 0o600 with full v1.2.0+
`{ tokens, scopes }` shape on success.

## Test plan

- [x] `npx vitest run` — 547 passed (529 + 18 new)
- [x] `npm run lint` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx prettier --check 'src/**/*.ts'` — clean
- [x] `npx vitest run --coverage` — `src/oauth-flow.ts` at 91.66%
      statements / 78.78% branches / 96.7% lines. Global coverage
      stays at ~86% statements.
- [x] Manual sanity: `node dist/index.js` (after `npm run build`)
      boots in lazy-auth mode when `~/.gmail-mcp` is empty and
      replays `tools/list` → returns `[]`