### PR TITLE
docs: README polish + comparison-table cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **README cleanup** — replaced the long "no third-party audit" NOTE block with a concise positive summary that names the divergence delta from upstream (121 commits / +26 700 / −10 400 lines vs `GongRzhe/Gmail-MCP-Server`, archived 2026-03-03) and the in-tree review chain (CodeRabbit + dual-model Qodo Merge). The detailed list of hardening controls moved out of the README and stays in [SECURITY.md](.github/SECURITY.md) where it belongs.
+- **README comparison table** — simplified: dropped the duplicate `GitHub repo` row (already in the column headers), the `CONTRIBUTING.md` and `.github/FUNDING.yml` rows (low signal — both are visible from the repo root), and the parenthetical clutter (`(outdated)`, `(multi-file tsc)`, `(target node22, ES2024)`). Updated `Active maintenance` to reflect that the upstream is archived. Test count and coverage floor bumped to `560 tests` / `>93%` to match the post-PR-#91 state.
+
+### Added
+
+- **Test coverage backfill (PR #91)** — 18 new tests across `src/tools/messaging.ts`, `src/tools/filters.ts`, `src/tools/downloads.ts`, and the prompts surface. Branch coverage on the four registrar files went up substantially (filters.ts 67% → 81%, messages.ts 64% → 67%, downloads.ts 61% → 63%). Mock helpers gained `messageGetHttpError` / `attachmentGetHttpError` / `failOnIds` options to make HTTP-error and per-item-batch-failure branches reachable from tests.
+
 ## [0.30.0] - 2026-04-26 — Server → McpServer migration + tool extraction
 
 A minor release that ships the full architectural cut-over from the

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/klodr)
 
 > [!NOTE]
-> This repository has not yet undergone a full independent third-party security review end-to-end. The hardening layer (path jails with `realpath` + `O_NOFOLLOW`, CRLF sanitization on both email-assembly paths, OAuth scope filtering at startup, Zod bounds on every Gmail ID, crypto MIME boundary, credentials at `0o600`, opt-in redacted JSONL audit log with counterparty-PII elision by default (`GMAIL_MCP_AUDIT_LOG` + `GMAIL_MCP_AUDIT_LOG_VERBOSE` opt-out), per-bucket daily+monthly write rate limits (send/delete/modify/drafts/labels/filters), LLM-output defense-in-depth fence (`<untrusted-tool-output>`) with control / zero-width / BiDi-override stripping on every tool response, attachment-filename neutralisation before disk write, protocol-error flagging (`isError: true`) on tool failures, Sigstore + SLSA + SBOM-signed releases, fast-check fuzz suite) is tested on every CI run. Against the two parent forks, `klodr/gmail-mcp` is already a meaningful step forward on prompt-injection and supply-chain posture. For mission-critical or high-sensitivity deployments, treat the server as carefully as any third-party MCP: prefer a narrowly-scoped OAuth token, enable human-in-the-loop confirmation on write tools, and track this repo's release notes for security-relevant updates. See [SECURITY.md](.github/SECURITY.md) for the detailed threat model.
+> Hardened + enhanced fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (archived 2026-03-03), via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Since the divergence point: **121 commits** (75 ahead of ArtyMcLabin) and **+26 700 / -10 400 lines** across security hardening, Gmail-surface improvements (reply-all, send-as alias, thread-level tools, download-to-disk, recipient pairing, batch ops with retry…), supply-chain hygiene, and CI gating. Every PR goes through CodeRabbit + dual-model Qodo Merge before merge. See [SECURITY.md](.github/SECURITY.md) for the controls and threat model, and the [comparison table](#-why-this-mcp) below for the parent-forks delta.
 
 A Model Context Protocol (MCP) server that lets AI assistants (Claude Desktop, Claude Code, Cursor, Continue, OpenClaw…) read and manage a Gmail account through scope-gated tools. Exposes the Gmail v1 API surface you actually need (messages, threads, labels, filters, attachments, drafts, reply-all) behind a single `npx` install.
 
@@ -58,13 +58,12 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | Zod bounds on `maxResults` / `batchSize` / `messageIds` length | ❌ | ❌ | ✅ |
 | Cryptographic MIME boundary (`crypto.randomBytes`, not `Math.random`) | ❌ | ❌ | ✅ |
 | **MCP protocol & tool surface** | | | |
-| MCP SDK version | v0.4.x (outdated) | v1.27.x | v1.29.x |
+| MCP SDK version | v0.4.x | v1.27.x | v1.29.x |
 | Tool annotations (`readOnlyHint` / `destructiveHint` / `idempotentHint`) | ❌ | ✅ | ✅ |
 | `llms-install.md` (LLM-readable install guide) | ❌ | ❌ | ✅ |
 | **Publishing / discoverability** | | | |
-| Published on npm | ✅ stale — no release since the fork diverged | ❌ (consumed as a GitHub install from the intermediate fork) | ✅ dedicated scoped package, signed releases |
-| GitHub repo | [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) | [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) | [klodr/gmail-mcp](https://github.com/klodr/gmail-mcp) |
-| Active maintenance (last 30 d) | ❌ (dormant since Aug 2025) | ⚠️ sporadic | ✅ daily review cycle (CodeRabbit + human) |
+| Published on npm | ❌ stale — no future releases (repo archived) | ❌ (consumed as a GitHub install from the intermediate fork) | ✅ dedicated scoped package, signed releases |
+| Active maintenance (last 30 d) | ❌ (archived 2026-03-03) | ⚠️ sporadic | ✅ daily review cycle (CodeRabbit + human) |
 | **Supply-chain integrity** | | | |
 | Node.js floor | ❌ `>=14` ([EOL April 2023](https://nodejs.org/en/about/previous-releases)) | ❌ `>=14` ([EOL April 2023](https://nodejs.org/en/about/previous-releases)) | ✅ `>=22` (Active LTS, maintenance until 2027-04-30) |
 | CI: CodeQL Advanced (`javascript-typescript` + `actions`) | ❌ | ❌ | ✅ |
@@ -73,10 +72,10 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | CI: CodeRabbit assertive reviews on every PR | ❌ | ❌ | ✅ |
 | Release: Sigstore-signed `dist/index.js` + SLSA in-toto attestation | ❌ | ❌ | ✅ |
 | Release: npm provenance statement | ❌ | ❌ | ✅ |
-| Release: single-file `tsup` ESM bundle (smaller tarball, easier to verify) | ❌ (multi-file `tsc`) | ❌ (multi-file `tsc`) | ✅ (target `node22`, `ES2024`) |
+| Release: single-file ESM bundle | ❌ | ❌ | ✅ |
 | **Testing** | | | |
-| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (529 tests) |
-| Statement coverage across `src/**` | 0% | 16.14% | **>86%** |
+| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (560 tests) |
+| Statement coverage across `src/**` | 0% | 16.14% | **>93%** |
 | Fast-check property-based fuzz suite | ❌ | ❌ | ✅ |
 | Hardening-specific test file (jails, CRLF, O_EXCL) | ❌ | ❌ | ✅ |
 | **CI/CD hardening** | | | |
@@ -86,8 +85,6 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | **Operational** | | | |
 | `CHANGELOG.md` (Keep-a-Changelog) | ❌ | ❌ | ✅ |
 | `SECURITY.md` (vulnerability reporting) | ❌ | ❌ | ✅ |
-| `CONTRIBUTING.md` | ❌ | ❌ | ✅ |
-| `.github/FUNDING.yml` | ❌ | ❌ | ✅ |
 
 `klodr/gmail-mcp` is the only one of the three with **(a)** source-path jails that make prompt-injection attachment exfiltration inert, **(b)** a modern supply chain (Scorecard, Socket, Sigstore), and **(c)** an in-repo review policy (`.coderabbit.yaml`) that every PR must pass before merge.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -9,6 +9,10 @@ Loose planning horizon of ~12 months, ordered by intent (not a commitment).
 - **MCP `outputSchema` per tool** — extend `defineTool()` with an optional `outputSchema?: ZodRawShape` parameter (`0.30.0` shipped the `inputSchema` half of the contract). Write a Zod schema for each of the 26 tools, derived from the `structuredContent` shape each handler returns today. Lets us drop the textual `RETURNS:` block from tool descriptions and rely on a machine-readable contract instead. Naturally pairs with the next minor release (`0.31.0` or similar).
 - **v1.0.0 on npm** — cut once the three items above land. Every release is already signed with Sigstore (keyless GitHub OIDC), ships an SLSA in-toto attestation, and carries npm provenance — the `0.x` line on npm has the same supply-chain posture, the `1.0.0` cut is purely a maturity / API-stability signal.
 
+## Shipped (post-v0.30.0, 2026-04-26)
+
+- ✅ **Test coverage backfill (#91)** — 18 new tests across `src/tools/messaging.ts`, `src/tools/filters.ts`, `src/tools/downloads.ts`, and the prompts surface. Brought the global statement coverage from ~81% (v0.30.0 cut) to **>93%** with 560 tests total. Branch coverage on the four registrar files went up substantially (filters.ts 67% → 81%, messages.ts 64% → 67%). Mock helpers gained `messageGetHttpError` / `attachmentGetHttpError` / `failOnIds` options to make HTTP-error and per-item-batch-failure branches reachable from tests.
+
 ## Shipped in v0.30.0 (2026-04-26)
 
 - ✅ **Migrate `Server` (legacy) → `McpServer` (ergonomic SDK API)** — the 1300-line `CallToolRequestSchema` switch dispatcher is gone. Every tool now lives in its own module under `src/tools/*.ts`, registered through a `defineTool()` wrapper that applies the OAuth scope filter at registration time so `tools/list` is auto-emitted by the SDK. `src/index.ts` shrunk from 2124 LOC to ~370 LOC.


### PR DESCRIPTION
## Summary

Doc-only PR — no code, no tests, no behaviour change.

- **README NOTE block** — replaced the long no-third-party-audit warning (~320 words listing every hardening control inline) with a concise positive summary (~110 words) that names the divergence delta vs upstream (`121 commits`, `+26 700 / −10 400 lines` vs `GongRzhe/Gmail-MCP-Server`, archived 2026-03-03) and the in-tree review chain (CodeRabbit + dual-model Qodo Merge). The detailed control inventory belongs in [SECURITY.md](.github/SECURITY.md), not the README intro.
- **Comparison table cleanup** — dropped 2 redundant rows (`GitHub repo` already in column headers; `CONTRIBUTING.md` + `.github/FUNDING.yml` are visible at repo root / sponsor button), trimmed parenthetical clutter (`(outdated)`, `(multi-file tsc)`, `(target node22, ES2024)`), refined `Active maintenance` to "archived 2026-03-03" (verified via `gh repo view`), and bumped test count + coverage floor (529 → 560 tests, `>86%` → `>93%`).
- **CHANGELOG.md `[Unreleased]`** — `Changed` section for the README polish + table cleanup, `Added` section for the PR #91 test coverage backfill that landed on main but wasn't yet documented.
- **docs/ROADMAP.md** — new `Shipped (post-v0.30.0)` section between `Near-term` and `Shipped in v0.30.0` to record PR #91 (mirrors the existing `Shipped (post-v0.10.0)` pattern; v0.30.0 release body stays untouched).

## Test plan

- [x] `npx prettier --check README.md CHANGELOG.md docs/ROADMAP.md` — clean
- [x] Visual diff review (5 cells in the table + the NOTE)
- [x] Numbers verified: 121 commits = `git log --oneline upstream/main..main | wc -l`; +26 740 / -10 457 lines = `git log --shortstat`; archived date = `gh repo view GongRzhe/Gmail-MCP-Server --json archivedAt`
- [x] Coverage floor `>93%` verified locally: `npx vitest run --coverage` → `93.19%` statements
- [ ] CI: prettier + markdown lint pass
- [ ] CR + Qodo (×2) review