### PR TITLE
fix(downloads): emit explicit structuredContent for download_email

### DIFF
--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -79,7 +79,7 @@ export function registerDownloadTools(
         const stats = fs.statSync(writtenPath);
 
         const result = {
-          status: "saved",
+          status: "saved" as const,
           path: writtenPath,
           size: stats.size,
           messageId,
@@ -88,8 +88,17 @@ export function registerDownloadTools(
           date,
           attachments,
         };
+        // Explicit structuredContent in addition to the JSON text
+        // — `attachStructuredContent` middleware would auto-attach
+        // here (the text starts with `{` and parses), but typing
+        // the result object as `as const` and lifting it
+        // explicitly guarantees the SDK validator sees the
+        // expected `downloadEmailOutputSchema` shape on every
+        // emit, decoupling correctness from the auto-attach
+        // best-effort heuristic.
         return {
           content: [{ type: "text", text: JSON.stringify(result, null, 2) }],
+          structuredContent: result,
         };
       } catch (error: unknown) {
         const { code, message } = asGmailApiError(error);

--- a/src/tools/registrars.test.ts
+++ b/src/tools/registrars.test.ts
@@ -1311,7 +1311,11 @@ describe("PR #6 registrars — download_email + download_attachment", () => {
       const result = (await fix.client.callTool({
         name: "download_email",
         arguments: { messageId: "msg_dl_json", savePath: downloadDir, format: "json" },
-      })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+      })) as {
+        content: Array<{ type: string; text: string }>;
+        isError?: boolean;
+        structuredContent?: Record<string, unknown>;
+      };
       expect(result.isError).toBeFalsy();
       const text = result.content[0]?.text ?? "";
       expect(text).toContain('"status": "saved"');
@@ -1319,6 +1323,18 @@ describe("PR #6 registrars — download_email + download_attachment", () => {
       // Verify the file actually exists in the jail.
       const written = readdirSync(downloadDir);
       expect(written).toContain("msg_dl_json.json");
+      // Pin the explicit structuredContent emission (PR #97 +
+      // follow-up). The handler now lifts the typed `result`
+      // object onto the structured channel directly instead of
+      // relying on `attachStructuredContent`'s auto-attach
+      // best-effort heuristic; the SDK validator then runs
+      // against `downloadEmailOutputSchema` on every emit.
+      expect(result.structuredContent).toBeDefined();
+      expect(result.structuredContent?.status).toBe("saved");
+      expect(result.structuredContent?.messageId).toBe("msg_dl_json");
+      expect(typeof result.structuredContent?.path).toBe("string");
+      expect(typeof result.structuredContent?.size).toBe("number");
+      expect(Array.isArray(result.structuredContent?.attachments)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## Summary

Follow-up to PR #97 (outputSchema infrastructure). CR Major outside-diff comment: `download_email` registered an `outputSchema` but the handler only emitted a JSON-text payload, relying on `attachStructuredContent` middleware to auto-lift it onto `structuredContent`. That couples the schema-validation correctness to the auto-attach best-effort heuristic.

Lift the typed `result` object onto `structuredContent` explicitly so the SDK validator sees the expected shape on every emit. `status: "saved" as const` keeps TS happy with the `z.literal("saved")` part of `downloadEmailOutputSchema`.

## Test update

Existing `download_email json format` test now also asserts the `structuredContent` payload:
- `status === "saved"`
- `messageId` matches the input
- `path` is a string (the saved jail path)
- `size` is a number
- `attachments` is an array

5 new assertions, no test count change.

## Test plan

- [x] `npx vitest run` — 631 passed
- [x] `npm run lint` — clean
- [x] `npx prettier --check 'src/**/*.ts'` — clean
- [x] `npx tsc --noEmit` — clean