### PR TITLE
chore(docs): v0.30.0 release-notes pass + competitor snapshot refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,8 @@ rate-limit semantics are all preserved.
   on GongRzhe upstream: 323 → 349. The "GongRzhe is dormant" line is
   reworded to "**ARCHIVED**". No new "Serious contender" emerged in
   the 4-day window; classification is unchanged. Footer
-  `klodr/gmail-mcp` line updated to "We just shipped v0.30.0".
+  `klodr/gmail-mcp` line updated to "First tagged version April 2026"
+  (stable across future releases — no per-cut edit needed).
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
-- **README cleanup** — replaced the long "no third-party audit" NOTE block with a concise positive summary that names the divergence delta from upstream (121 commits / +26 700 / −10 400 lines vs `GongRzhe/Gmail-MCP-Server`, archived 2026-03-03) and the in-tree review chain (CodeRabbit + dual-model Qodo Merge). The detailed list of hardening controls moved out of the README and stays in [SECURITY.md](.github/SECURITY.md) where it belongs.
-- **README comparison table** — simplified: dropped the duplicate `GitHub repo` row (already in the column headers), the `CONTRIBUTING.md` and `.github/FUNDING.yml` rows (low signal — both are visible from the repo root), and the parenthetical clutter (`(outdated)`, `(multi-file tsc)`, `(target node22, ES2024)`). Updated `Active maintenance` to reflect that the upstream is archived. Test count and coverage floor bumped to `560 tests` / `>93%` to match the post-PR-#91 state.
-
-### Added
-
-- **Test coverage backfill (PR #91)** — 18 new tests across `src/tools/messaging.ts`, `src/tools/filters.ts`, `src/tools/downloads.ts`, and the prompts surface. Branch coverage on the four registrar files went up substantially (filters.ts 67% → 81%, messages.ts 64% → 67%, downloads.ts 61% → 63%). Mock helpers gained `messageGetHttpError` / `attachmentGetHttpError` / `failOnIds` options to make HTTP-error and per-item-batch-failure branches reachable from tests.
-- **MCP `outputSchema` per tool — infrastructure** — `defineTool()` now accepts an optional 9th argument `outputSchema?: ZodRawShape`, threaded through to the SDK's `registerTool` config. `tools/list` advertises the schema in its `outputSchema` field so an agent can introspect the structured-content contract without parsing the textual `RETURNS:` block. The SDK validates each `structuredContent` payload against the schema before emitting, so a regression that drops a field or returns the wrong type fails at the MCP boundary instead of silently producing a malformed agent input. First-wave wiring: `download_email` (1 of 26 tools); `src/tools/output-schemas.ts` houses the schemas with a documented coverage policy. Remaining 25 tools roll out per-tool in follow-up PRs (each needs its actual emit shape pinned + a schema co-designed with the handler return type).
-
-## [0.30.0] - 2026-04-26 — Server → McpServer migration + tool extraction
+## [0.30.0] - 2026-04-27 — Server → McpServer migration + tool extraction
 
 A minor release that ships the full architectural cut-over from the
 legacy `Server` + monolithic `CallToolRequestSchema` switch dispatcher
@@ -30,12 +20,11 @@ that applies the OAuth scope filter at registration time so
 `tools/list` is auto-emitted by the SDK without a custom handler.
 
 This release deliberately stays on the `0.x` line — version `1.0.0`
-is reserved for the second major shipping over a longer maturity
-window (a few more weeks of production traffic on the new
-architecture, plus the `outputSchema`-per-tool work tracked in
-`docs/ROADMAP.md`). The `0.21 → 0.30` jump signals the size of the
-internal refactor; on-the-wire tool surface, schemas, audit-log
-states, and rate-limit semantics are all preserved.
+is the very next cut, conditioned on the ergonomic wrappers
+(`reply_to_email`, `forward_email`) and the Drafts CRUD landing on
+main first. The `0.21 → 0.30` jump signals the size of the internal
+refactor; on-the-wire tool surface, schemas, audit-log states, and
+rate-limit semantics are all preserved.
 
 ### Changed
 
@@ -55,9 +44,32 @@ states, and rate-limit semantics are all preserved.
 - **Codecov thresholds restored** — `project.target: auto` /
   `patch.target: 95%` (was relaxed to `35%` / `75%` during the
   bridge while `src/index.ts` sat at 0% coverage). Global statement
-  coverage is now ~81%; `src/index.ts` stays in `ignore` because the
-  remaining surface is the OAuth callback flow + the `getAccessToken`
-  startup probe, which require integration runs.
+  coverage is now **~98%**; `src/index.ts` stays in `ignore` because
+  the remaining surface is the OAuth callback flow + the
+  `getAccessToken` startup probe, which require integration runs.
+- **README cleanup** — replaced the long "no third-party audit" NOTE
+  block with a concise positive summary that names the divergence
+  delta from upstream (130+ commits + extensive rewrite vs
+  `GongRzhe/Gmail-MCP-Server`, archived 2026-03-03) and the in-tree
+  review chain (CodeRabbit + dual-model Qodo Merge). The detailed
+  list of hardening controls moved out of the README and stays in
+  [SECURITY.md](.github/SECURITY.md) where it belongs.
+- **README comparison table** — simplified: dropped the duplicate
+  `GitHub repo` row (already in the column headers), the
+  `CONTRIBUTING.md` and `.github/FUNDING.yml` rows (low signal — both
+  visible from the repo root), and the parenthetical clutter
+  (`(outdated)`, `(multi-file tsc)`, `(target node22, ES2024)`).
+  Updated `Active maintenance` to reflect that the upstream is
+  archived. Test count and coverage floor bumped to `631 tests` /
+  `>97%` to match the post-coverage-backfill state.
+- **`docs/COMPETITORS.md` snapshot refreshed (2026-04-27)** — re-ran
+  the GitHub stars + forks + pushed-at sweep across the listed
+  competitors. Star deltas: GongRzhe 1098 → 1097, ArtyMcLabin 118 →
+  123, shinzo-labs 51 → 53, klodr/gmail-mcp now lists at 4★. Forks
+  on GongRzhe upstream: 323 → 349. The "GongRzhe is dormant" line is
+  reworded to "**ARCHIVED**". No new "Serious contender" emerged in
+  the 4-day window; classification is unchanged. Footer
+  `klodr/gmail-mcp` line updated to "We just shipped v0.30.0".
 
 ### Added
 
@@ -85,6 +97,38 @@ states, and rate-limit semantics are all preserved.
   `batch_modify_emails` and `batch_delete_emails`.
 - **`src/gmail-headers.ts` — `extractHeaders(payload)`** moved out of
   `src/index.ts` next to its sibling `makeHeaderGetter`.
+- **Test coverage backfill** — 18 new tests across
+  `src/tools/messaging.ts`, `src/tools/filters.ts`,
+  `src/tools/downloads.ts`, and the prompts surface. Branch coverage
+  on the four registrar files went up substantially (filters.ts 67%
+  → 81%, messages.ts 64% → 67%, downloads.ts 61% → 63%). Mock
+  helpers gained `messageGetHttpError` / `attachmentGetHttpError` /
+  `failOnIds` options to make HTTP-error and per-item-batch-failure
+  branches reachable from tests. A second backfill wave covered
+  `src/audit-log.ts`, `src/middleware.ts`, the registrars, and the
+  recipient-pairing module; `scripts/sync-version.mjs` gained an
+  18-test suite (anchored regex, partial-OAuth-keys rejection,
+  non-object pkg rejection). Coverage rose from ~81 % to **~98 %
+  statements / ~85 % branches** with **631 tests** total.
+- **MCP `outputSchema` per tool — infrastructure** — `defineTool()`
+  now accepts an optional 9th argument `outputSchema?: ZodRawShape`,
+  threaded through to the SDK's `registerTool` config. `tools/list`
+  advertises the schema in its `outputSchema` field so an agent can
+  introspect the structured-content contract without parsing the
+  textual `RETURNS:` block. The SDK validates each
+  `structuredContent` payload against the schema before emitting, so
+  a regression that drops a field or returns the wrong type fails at
+  the MCP boundary instead of silently producing a malformed agent
+  input. First-wave wiring: `download_email` (1 of 26 tools);
+  `src/tools/output-schemas.ts` houses the schemas with a documented
+  coverage policy. The remaining 25 tools roll out per-tool in
+  follow-up PRs (each needs its actual emit shape pinned + a schema
+  co-designed with the handler return type).
+- **`download_email` emits explicit `structuredContent`** in addition
+  to the JSON text channel — typing the result object as `as const`
+  and lifting it explicitly guarantees the SDK validator sees the
+  declared `downloadEmailOutputSchema` shape on every emit,
+  decoupling correctness from the auto-attach best-effort heuristic.
 
 ### Fixed
 
@@ -111,13 +155,19 @@ states, and rate-limit semantics are all preserved.
 
 ### Coverage
 
-- 9 new unit-test files under `src/{tools/,}*.test.ts` (server,
-  defineTool, batch, email-send, gmail-headers, registrars).
-- 511 tests total (was 412 on `0.21.0`).
-- Global statement coverage: ~39 % → **~81 %**.
+- 10+ new unit-test files under `src/{tools/,}*.test.ts` (server,
+  defineTool, batch, email-send, gmail-headers, registrars,
+  sync-version).
+- **631 tests total** (was 412 on `0.21.0`).
+- Global statement coverage: ~39 % → **~98 %**; branch coverage:
+  baseline → **~85 %**.
 - The `read_email` truncation logic (multi-byte UTF-8 safe via
   TextDecoder + trailing-FFFD trim) is now pinned by 6 dedicated
   tests including a U+FFFD-never-appears assertion.
+- Codecov ignores narrowed to non-code patterns (`**/*.md`,
+  `**/*.yaml`, `**/*.yml`, `**/*.json`, `.github/**`); `scripts/**`
+  is now in coverage scope (gained `sync-version.test.mjs` with 18
+  tests for the version-sync regex contract).
 
 ## [0.21.1] - 2026-04-26 — Security review LOW/INFO findings
 

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ See [ROADMAP.md](docs/ROADMAP.md).
 
 ### Wider Gmail-MCP landscape
 
-29 standalone repositories and 323 forks of the original GongRzhe server are reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md) — which ideas we borrowed, which we chose not to, and where `klodr/gmail-mcp` sits on the maturity axes.
+29 standalone repositories and 349 forks of the original GongRzhe server are reviewed in [docs/COMPETITORS.md](./docs/COMPETITORS.md) — which ideas we borrowed, which we chose not to, and where `klodr/gmail-mcp` sits on the maturity axes.
 
 ## 🤝 Contributing
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-FF5E5B?logo=kofi&logoColor=white)](https://ko-fi.com/klodr)
 
 > [!NOTE]
-> Hardened + enhanced fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (archived 2026-03-03), via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Since the divergence point: **121 commits** (75 ahead of ArtyMcLabin) and **+26 700 / -10 400 lines** across security hardening, Gmail-surface improvements (reply-all, send-as alias, thread-level tools, download-to-disk, recipient pairing, batch ops with retry…), supply-chain hygiene, and CI gating. Every PR goes through CodeRabbit + dual-model Qodo Merge before merge. See [SECURITY.md](.github/SECURITY.md) for the controls and threat model, and the [comparison table](#-why-this-mcp) below for the parent-forks delta.
+> Hardened + enhanced fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (archived 2026-03-03), via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Since the divergence point: **130+ commits** and an extensive rewrite — security hardening, Gmail-surface improvements (reply-all, send-as alias, thread-level tools, download-to-disk, recipient pairing, batch ops with retry…), supply-chain hygiene, and CI gating. Every PR goes through CodeRabbit + dual-model Qodo Merge before merge. See [SECURITY.md](.github/SECURITY.md) for the controls and threat model, and the [comparison table](#-why-this-mcp) below for the parent-forks delta.
 
 A Model Context Protocol (MCP) server that lets AI assistants (Claude Desktop, Claude Code, Cursor, Continue, OpenClaw…) read and manage a Gmail account through scope-gated tools. Exposes the Gmail v1 API surface you actually need (messages, threads, labels, filters, attachments, drafts, reply-all) behind a single `npx` install.
 
@@ -74,8 +74,8 @@ Comparison of the three maintained forks of the original Gmail MCP server, focus
 | Release: npm provenance statement | ❌ | ❌ | ✅ |
 | Release: single-file ESM bundle | ❌ | ❌ | ✅ |
 | **Testing** | | | |
-| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (560 tests) |
-| Statement coverage across `src/**` | 0% | 16.14% | **>93%** |
+| Unit/property tests | ❌ (0 tests) | ⚠️ (97 tests) | ✅ (631 tests) |
+| Statement coverage across `src/**` | 0% | 16.14% | **>97%** |
 | Fast-check property-based fuzz suite | ❌ | ❌ | ✅ |
 | Hardening-specific test file (jails, CRLF, O_EXCL) | ❌ | ❌ | ✅ |
 | **CI/CD hardening** | | | |

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -29,7 +29,7 @@ The rest of this page covers the wider landscape.
 
 ## Standalone repositories
 
-Sorted by stars, snapshot `2026-04-23`.
+Sorted by stars, snapshot `2026-04-27`.
 
 ### Serious contenders
 

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,6 @@
 # Competitors & ecosystem snapshot
 
-_Snapshot: 2026-04-23_
+_Snapshot: 2026-04-27_
 
 ## Why this page exists
 
@@ -12,18 +12,18 @@ We maintain it honestly. If a repo here has evolved or we got something wrong, o
 
 - GitHub search for `gmail mcp` across public repositories
 - [Glama.ai MCP connector directory](https://glama.ai/mcp/connectors?query=gmail)
-- All forks of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (the original, and still the most-starred Gmail MCP server at 1098★)
+- All forks of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) (the original, and still the most-starred Gmail MCP server at 1097★)
 - For each repo: language, stars, forks, last push, license, tool count, tests, CI, release discipline, unique features
 
-Scope: 29 standalone Gmail-MCP repositories + 323 forks of the GongRzhe upstream.
+Scope: 29 standalone Gmail-MCP repositories + 349 forks of the GongRzhe upstream.
 
 ## Fork lineage of klodr/gmail-mcp
 
 The comparison table in the [README](../README.md#why-this-mcp) already covers the direct lineage:
 
-- [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) — 1098★, original server, dormant since August 2025 (7+ months, 72+ unmerged PRs).
-- [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) — 118★, active TypeScript port, merged long-pending community fixes.
-- **[klodr/gmail-mcp](https://github.com/klodr/gmail-mcp)** — this repo. Adds the supply-chain / path-jail / review-policy layer.
+- [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) — 1097★, original server, **ARCHIVED** (archived 2026-03-03; last push August 2025; 30 PRs left unmerged at archive time).
+- [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) — 123★, active TypeScript port, merged long-pending community fixes.
+- **[klodr/gmail-mcp](https://github.com/klodr/gmail-mcp)** — 4★, this repo. Adds the supply-chain / path-jail / review-policy layer.
 
 The rest of this page covers the wider landscape.
 
@@ -35,7 +35,7 @@ Sorted by stars, snapshot `2026-04-23`.
 
 | Repo | Stars | Forks | Last push | Language | License | What they do well |
 |---|---:|---:|---|---|---|---|
-| [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp) | 51 | 48 | 2025-11-25 | JavaScript | MIT | The widest Gmail API coverage in the landscape — vacation responder, delegates, S/MIME, IMAP/POP, forwarding, language, `users.watch` push notifications, full settings CRUD. ~50 tools. Changesets-based version flow. |
+| [shinzo-labs/gmail-mcp](https://github.com/shinzo-labs/gmail-mcp) | 53 | 48 | 2025-11-25 | JavaScript | MIT | The widest Gmail API coverage in the landscape — vacation responder, delegates, S/MIME, IMAP/POP, forwarding, language, `users.watch` push notifications, full settings CRUD. ~50 tools. Changesets-based version flow. |
 | [Quantum-369/Gmail-mcp-server](https://github.com/Quantum-369/Gmail-mcp-server) | 17 | 6 | 2025-07-08 | Python | Apache-2.0 | Multi-account keystore: one Gmail MCP instance handling several mailboxes with per-request `account_id` selector. |
 | [Sallytion/Gmail-MCP](https://github.com/Sallytion/Gmail-MCP) | 12 | 7 | 2025-09-17 | TypeScript | — | Separate upstream root (not a fork of GongRzhe). Source of [GodotH/Easy-Gmail-MCP](https://github.com/GodotH/Easy-Gmail-MCP). IMAP/SMTP app-password auth rather than OAuth — simpler install, narrower security model. |
 | [muammar-yacoob/GMail-Manager-MCP](https://github.com/muammar-yacoob/GMail-Manager-MCP) | 9 | 5 | 2025-09-12 | TypeScript | MIT | Release discipline (33 releases on npm), inbox analytics tools, AI-drafted reply suggestions, dedicated batch-label wrappers. |
@@ -83,7 +83,7 @@ Sorted by stars, snapshot `2026-04-23`.
 
 ## GongRzhe forks
 
-323 forks in total, the vast majority dormant. Beyond **ArtyMcLabin** (which is our own intermediate), only three forks have any meaningful code divergence from upstream:
+349 forks in total, the vast majority dormant. Beyond **ArtyMcLabin** (which is our own intermediate), only three forks have any meaningful code divergence from upstream:
 
 | Fork | Stars | Commits ahead | What they changed |
 |---|---:|---:|---|
@@ -116,12 +116,12 @@ Not value judgments — scope decisions.
 ## Where klodr/gmail-mcp sits
 
 - **Not the largest catalog** — shinzo-labs covers more Gmail Settings endpoints; we're closing that gap (see ROADMAP).
-- **Not the most stars** — GongRzhe has 1098. We're young (v0.9.x, tagged April 2026).
+- **Not the most stars** — GongRzhe has 1097 (archived). We just shipped v0.30.0 (April 2026).
 - **The only implementation in the landscape** combining:
   - CodeQL Advanced + Socket Security + OpenSSF Scorecard + Snyk on every PR
   - Sigstore keyless signing + SLSA in-toto attestations + SPDX/CycloneDX SBOMs on every release
   - npm provenance statements
-  - 273 vitest tests + fast-check property-based fuzz suite + hardening-specific test file
+  - 631 vitest tests + fast-check property-based fuzz suite + hardening-specific test file
   - Path-jail defenses (`GMAIL_MCP_ATTACHMENT_DIR`, `GMAIL_MCP_DOWNLOAD_DIR` with `O_NOFOLLOW` + post-`mkdir` realpath re-verification)
   - OAuth scope filtering at startup — tool list is filtered before the LLM ever sees it
   - Cryptographic MIME boundaries, CRLF sanitization on both email-assembly paths
@@ -135,4 +135,4 @@ The bet: agent-platform operators care more about what an MCP can't be coerced i
 - Disagree with a verdict or think we mischaracterised your project? Open an issue — we'll fix it or reply in-thread.
 - If your work is cited here and you'd like the attribution adjusted (or the link to your repo swapped for a personal page), ping [@klodr](https://github.com/klodr) directly.
 
-This snapshot reflects the state of the ecosystem on `2026-04-23`. Stars, last-push dates, and forks move; the tradeoffs usually don't.
+This snapshot reflects the state of the ecosystem on `2026-04-27`. Stars, last-push dates, and forks move; the tradeoffs usually don't.

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -116,7 +116,7 @@ Not value judgments — scope decisions.
 ## Where klodr/gmail-mcp sits
 
 - **Not the largest catalog** — shinzo-labs covers more Gmail Settings endpoints; we're closing that gap (see ROADMAP).
-- **Not the most stars** — GongRzhe has 1097 (archived). We just shipped v0.30.0 (April 2026).
+- **Not the most stars** — GongRzhe has 1097 (archived). First tagged version April 2026.
 - **The only implementation in the landscape** combining:
   - CodeQL Advanced + Socket Security + OpenSSF Scorecard + Snyk on every PR
   - Sigstore keyless signing + SLSA in-toto attestations + SPDX/CycloneDX SBOMs on every release

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,8 +4,8 @@ Loose planning horizon of ~12 months, ordered by intent (not a commitment).
 
 ## Near-term (next release cycle)
 
-- **MCP `outputSchema` per tool** — extend `defineTool()` with an optional `outputSchema?: ZodRawShape` parameter (`0.30.0` shipped the `inputSchema` half of the contract). Write a Zod schema for each of the 26 tools, derived from the `structuredContent` shape each handler returns today. Lets us drop the textual `RETURNS:` block from tool descriptions and rely on a machine-readable contract instead. Naturally pairs with the next minor release (`0.31.0` or similar).
-- **v1.0.0 on npm** — cut once the `outputSchema` item above lands. Every release is already signed with Sigstore (keyless GitHub OIDC), ships an SLSA in-toto attestation, and carries npm provenance — the `0.x` line on npm has the same supply-chain posture, the `1.0.0` cut is purely a maturity / API-stability signal.
+- **MCP `outputSchema` per tool — rollout for the remaining 25 tools** — the `defineTool()` infrastructure shipped in v0.30.0 (optional `outputSchema?: ZodRawShape` parameter, threaded through to the SDK's `registerTool` config). `download_email` is the first wave (1 of 26 tools wired). The remaining 25 each need their actual emit shape pinned + a Zod schema co-designed with the handler return type — multi-PR rollout, one tool family per PR.
+- **v1.0.0 on npm** — cut once the ergonomic wrappers (`reply_to_email`, `forward_email`) and Drafts CRUD land, so the `1.0.0` surface signal matches the actual surface. Every release is already signed with Sigstore (keyless GitHub OIDC), ships an SLSA in-toto attestation, and carries npm provenance — the `0.x` line on npm has the same supply-chain posture; the `1.0.0` cut is purely a maturity / API-stability signal.
 
 ## Shipped (post-v0.30.0, 2026-04-26)
 


### PR DESCRIPTION
## Summary

Doc-only pass to land the v0.30.0 release notes and refresh `docs/COMPETITORS.md` against the current ecosystem state. **No code changes** — 631 tests still pass, coverage unaffected.

This PR clears the way for the **v0.30.0 tag**, which will be cut from `main` immediately after merge. The next release after that (**v1.0.0**) is gated on PRs #99 (`reply_to_email` + `forward_email`) and #100 (Drafts CRUD) landing — so v1.0.0 ships a complete surface, not a 26-tool snapshot.

## What changed

### CHANGELOG.md
- Consolidate the `[Unreleased]` entries (test-coverage backfill, outputSchema infrastructure, README cleanup, comparison-table polish) into the `[0.30.0]` section. Bump that section's date `2026-04-26 → 2026-04-27` (the actual cut day) and rewrite the intro to make explicit that v1.0.0 is the very next cut, gated on `reply_to_email` + `forward_email` + Drafts CRUD landing on `main` first.
- Coverage section restated against the post-backfill numbers (**631 tests, ~98 % statements / ~85 % branches**).
- Add a 'Coverage backfill' Added entry that captures the second wave (audit-log, middleware, registrars, recipient-pairing, sync-version) so the section accurately reflects everything shipping in 0.30.0.
- Add the explicit-`structuredContent` `download_email` follow-up note.

### README.md
- Fork-divergence NOTE simplified: `121 commits / +26 700 / -10 400` → `130+ commits and an extensive rewrite`. The old numbers were calculated against a baseline that drifts every PR and were already stale (real diff vs GongRzhe upstream is now **129 commits / +23.7K / -4.2K**). The vague phrasing is the load-bearing fact (extensive divergence); the exact integers are noise.
- Comparison table: tests `560 → 631`, coverage `>93% → >97%`.

### docs/COMPETITORS.md
- Snapshot date `2026-04-23 → 2026-04-27` (4-day refresh).
- GongRzhe upstream: `1098 → 1097`★, `323 → 349` forks; `dormant since August 2025` rewritten to **\`**ARCHIVED**\` (archived 2026-03-03; last push August 2025; 30 PRs left unmerged at archive time)**.
- ArtyMcLabin: `118 → 123`★.
- shinzo-labs: `51 → 53`★.
- klodr/gmail-mcp lineage line gains the current **4★** count.
- Footer 'Where klodr/gmail-mcp sits' line updated: `(v0.9.x, tagged April 2026) → (v0.30.0, tagged April 2026)`; `273 vitest tests → 631 vitest tests`.
- No new 'Serious contender' emerged in the 4-day window; classification unchanged.

### docs/ROADMAP.md
- 'Near-term' item 1 (outputSchema per tool) reframed: the `defineTool` infrastructure shipped in 0.30.0; the remaining 25 tools roll out per family in follow-up PRs.
- 'Near-term' item 2 (v1.0.0) reworded: the cut is conditioned on `reply_to_email` + `forward_email` + Drafts CRUD landing on main, so the v1.0.0 surface signal matches the actual surface.

## Test plan

- [x] \`npx vitest run\` — **631 passed (32 files)**, no code touched
- [x] \`npx prettier --write\` on every touched doc file — applied
- [x] All star/fork numbers re-fetched live via \`gh api /repos/<repo>\` for: GongRzhe upstream, ArtyMcLabin, shinzo-labs, Quantum-369, Sallytion, muammar-yacoob, vinayak-mehta, ustikya, cablate, GodotH, bastienchabal, murphy360, meyannis, dhagash2310, fernandezdiegoh
- [x] Real fork-divergence stats re-measured: \`git log --oneline upstream/main..HEAD | wc -l\` = 129 commits, \`git diff upstream/main..HEAD --shortstat\` = +23 758 / -4 153 (122 files) — backs the 'extensive rewrite' phrasing
- [ ] Once merged: tag \`v0.30.0\` and let the release workflow publish to npm