### PR TITLE
release: v0.30.1 — workflow_dispatch escape hatch + version bump

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -24,6 +24,14 @@ on:
       - "tsup.config.ts"
       - ".github/workflows/docker.yml"
   merge_group:
+  # Manual trigger so the check can be re-run on a commit whose
+  # paths-filter excluded the Docker workflow (e.g. doc-only PR
+  # merges to main). Without this, the branch protection rule that
+  # marks "Build Docker image" as a required status check
+  # indefinitely blocks tag pushes whenever main HEAD is a
+  # docs-only commit. `workflow_dispatch` lets `gh workflow run
+  # docker.yml --ref main` re-trigger the build on demand.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.30.0] - 2026-04-27 — Server → McpServer migration + tool extraction
+## [0.30.1] - 2026-04-27 — Server → McpServer migration + tool extraction
 
 A minor release that ships the full architectural cut-over from the
 legacy `Server` + monolithic `CallToolRequestSchema` switch dispatcher
@@ -25,6 +25,15 @@ is the very next cut, conditioned on the ergonomic wrappers
 main first. The `0.21 → 0.30` jump signals the size of the internal
 refactor; on-the-wire tool surface, schemas, audit-log states, and
 rate-limit semantics are all preserved.
+
+The patch-level bump `0.30.0 → 0.30.1` (no `0.30.0` was ever
+published to npm) absorbs a CI workflow fix that unblocked the
+release: the doc-pass merge to `main` did not touch any
+Docker-workflow path, so the required "Build Docker image" status
+check never ran on `main` HEAD and indefinitely blocked the tag
+push. Adding `workflow_dispatch` to `.github/workflows/docker.yml`
+lets the same scenario be unblocked on demand on future doc-only
+releases via `gh workflow run docker.yml --ref main`.
 
 ### Changed
 
@@ -133,6 +142,14 @@ rate-limit semantics are all preserved.
 
 ### Fixed
 
+- **`.github/workflows/docker.yml`** — added `workflow_dispatch` as
+  a third trigger so the required "Build Docker image" status check
+  can be re-run on demand against a `main` HEAD whose paths-filter
+  excluded the Docker workflow (e.g. doc-only PR merges). Without
+  this, a doc-only merge to `main` indefinitely blocks tag pushes
+  because branch protection sees the required check as 'expected
+  but absent'. Same convention as the standard CI workflows in the
+  sibling klodr repos.
 - **`getOrCreateLabel` returns `{ label, found }`** instead of a bare
   `GmailLabel`. The previous `result.type === "user" && result.name
   === args.name` heuristic the call site used to distinguish "found

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -420,8 +420,8 @@ the 25-tool dispatcher (tracked in `ROADMAP.md`).
 
 This repository is a fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Pre-fork changelog is not reproduced here — see the upstream history and the acknowledgments in the README.
 
-[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v0.30.0...HEAD
-[0.30.0]: https://github.com/klodr/gmail-mcp/compare/v0.21.1...v0.30.0
+[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v0.30.1...HEAD
+[0.30.1]: https://github.com/klodr/gmail-mcp/compare/v0.21.1...v0.30.1
 [0.21.1]: https://github.com/klodr/gmail-mcp/compare/v0.21.0...v0.21.1
 [0.21.0]: https://github.com/klodr/gmail-mcp/compare/v0.20.0...v0.21.0
 [0.20.0]: https://github.com/klodr/gmail-mcp/compare/v0.10.0...v0.20.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "0.30.0",
+  "version": "0.30.1",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "0.30.0",
+      "version": "0.30.1",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,7 @@ import {
 // `npm version patch|minor|major`. Mirrors the same convention used in
 // klodr/mercury-invoicing-mcp/src/server.ts:VERSION and
 // klodr/faxdrop-mcp/src/server.ts:VERSION.
-export const VERSION = "0.30.0";
+export const VERSION = "0.30.1";
 
 export interface ServerOptions {
   /**


### PR DESCRIPTION
## Summary

Two things in one release-prep PR:

1. **`ci(docker)`** — adds `workflow_dispatch` as a third trigger to `.github/workflows/docker.yml`. Without it, a doc-only PR merge to `main` indefinitely blocks tag pushes (the 'Build Docker image' check is required by branch protection but the workflow's paths-filter excludes doc-only commits). With it, `gh workflow run docker.yml --ref main` re-triggers the build on demand. **This is what unblocks the v0.30.0 tag.**
2. **`chore`** — bump `0.30.0 → 0.30.1` (both `package.json` and `src/server.ts:VERSION`) so the tag pushed to npm matches the code that actually shipped (the workflow fix is a real change). The CHANGELOG `[0.30.0]` section header is renamed in place to `[0.30.1]`; a paragraph in the intro explains the in-transit bump.

After merge, `npm version` is **not** needed — `package.json` is already at `0.30.1`. Just `git tag -a v0.30.1 -m '...' && git push origin v0.30.1` on `main`. The Docker check will have run on this PR (because it touches `.github/workflows/docker.yml` AND `package.json`, both in the workflow's paths-filter), so the `main` HEAD post-merge will satisfy the required check and the tag push is unblocked.

## Test plan

- [x] \`npx vitest run\` — **631 passed (32 files)**, no code change beyond version constants
- [x] \`npx tsc --noEmit\` — clean
- [x] CHANGELOG entry header renamed [0.30.0] → [0.30.1] in place; no entries duplicated
- [x] \`package.json\` and \`src/server.ts\` VERSION are in sync (0.30.1) — \`scripts/sync-version.mjs\` contract maintained
- [ ] Once merged, tag v0.30.1 + push triggers the release workflow → npm publish