### PR TITLE
chore(deps): bump nodemailer 8.0.7 + zod 4.4.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
         "email-addresses": "^5.0.0",
         "google-auth-library": "^10.6.2",
         "googleapis": "^171.4.0",
-        "nodemailer": "^8.0.6",
+        "nodemailer": "^8.0.7",
         "open": "^11.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.4.2"
       },
       "bin": {
         "gmail-mcp": "dist/index.js"
@@ -4719,9 +4719,9 @@
       }
     },
     "node_modules/nodemailer": {
-      "version": "8.0.6",
-      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.6.tgz",
-      "integrity": "sha512-Nm2XeuDwwy2wi5A+8jPWwQwNzcjNjhWdE3pVLoXEusxJqCnAPAgnBGkSmiLknbnWuOF9qraRpYZjfxqtKZ4tPw==",
+      "version": "8.0.7",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-8.0.7.tgz",
+      "integrity": "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow==",
       "license": "MIT-0",
       "engines": {
         "node": ">=6.0.0"
@@ -6242,9 +6242,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
-      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.2.tgz",
+      "integrity": "sha512-IynmDyxsEsb9RKzO3J9+4SxXnl2FTFSzNBaKKaMV6tsSk0rw9gYw9gs+JFCq/qk2LCZ78KDwyj+Z289TijSkUw==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -65,9 +65,9 @@
     "email-addresses": "^5.0.0",
     "google-auth-library": "^10.6.2",
     "googleapis": "^171.4.0",
-    "nodemailer": "^8.0.6",
+    "nodemailer": "^8.0.7",
     "open": "^11.0.0",
-    "zod": "^4.3.6"
+    "zod": "^4.4.2"
   },
   "devDependencies": {
     "@codecov/bundle-analyzer": "^2.0.1",


### PR DESCRIPTION
## Summary

Pre-empts the weekly dependabot run (Monday 2026-05-04) which would otherwise open the same bumps grouped under `production-dependencies`.

- `nodemailer` 8.0.6 → 8.0.7 (patch)
- `zod` 4.3.6 → 4.4.2 (minor — `zod` schemas are pervasive in this repo, so isolated on its own PR for independent triage if anything regresses)

The companion `dev-dependencies` bump landed in [PR 106 (eslint + typescript-eslint)](https://github.com/klodr/gmail-mcp/pull/106).

## Test plan

- [x] `npm test` — 675/675 green against zod 4.4.2
- [x] `npm run build` clean (172 KB ESM bundle, identical to baseline)
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean
- [ ] CodeRabbit + Qodo (DeepSeek + Gemini) reviews