### PR TITLE
chore(release): v1.1.0 — dependency refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-05-03 — Dependency refresh
+
+### Changed
+
+- **`zod`** 4.3.6 → 4.4.2 (production). Schemas drive every tool input/output in this repo; bumped on its own PR (#107) for independent triage. Tests 675/675 pass against the new minor.
+- **`nodemailer`** 8.0.6 → 8.0.7 (production, patch).
+- **`eslint`** 10.2.1 → 10.3.0 (dev, minor).
+- **`typescript-eslint`** 8.59.0 → 8.59.1 (dev, patch).
+
+Pre-empts the weekly dependabot run rather than letting it open the bumps over multiple cycles. Two PRs: dev-deps (#106) and prod-deps (#107).
+
 ## [1.0.0] - 2026-04-28 — Drafts CRUD + ergonomic wrappers (API stability cut)
 
 The `1.0.0` cut is a **maturity / API-stability signal**, not a supply-chain step
@@ -438,7 +449,8 @@ the 25-tool dispatcher (tracked in `ROADMAP.md`).
 
 This repository is a fork of [GongRzhe/Gmail-MCP-Server](https://github.com/GongRzhe/Gmail-MCP-Server) via [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server). Pre-fork changelog is not reproduced here — see the upstream history and the acknowledgments in the README.
 
-[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v1.0.0...HEAD
+[Unreleased]: https://github.com/klodr/gmail-mcp/compare/v1.1.0...HEAD
+[1.1.0]: https://github.com/klodr/gmail-mcp/compare/v1.0.0...v1.1.0
 [1.0.0]: https://github.com/klodr/gmail-mcp/compare/v0.30.1...v1.0.0
 [0.30.1]: https://github.com/klodr/gmail-mcp/compare/v0.21.1...v0.30.1
 [0.21.1]: https://github.com/klodr/gmail-mcp/compare/v0.21.0...v0.21.1

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@klodr/gmail-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@klodr/gmail-mcp",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Gmail MCP server — scope-gated tools + attachment/download path jails + supply-chain hardening. Fork of GongRzhe/Gmail-MCP-Server via ArtyMcLabin's intermediate fork.",
   "type": "module",
   "main": "dist/index.js",

--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-09-29/server.schema.json",
   "name": "io.github.klodr/gmail-mcp",
   "description": "Gmail MCP server — scope-gated tools (read-only / send-only / modify) with attachment and download path jails, OAuth credentials hardened to 0o600, supply-chain hardening (Sigstore attestations + SPDX/CycloneDX SBOMs + npm provenance).",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "repository": {
     "url": "https://github.com/klodr/gmail-mcp",
     "source": "github"
@@ -11,7 +11,7 @@
     {
       "registryType": "npm",
       "identifier": "@klodr/gmail-mcp",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,7 +26,7 @@ import {
 // `npm version patch|minor|major`. Mirrors the same convention used in
 // klodr/mercury-invoicing-mcp/src/server.ts:VERSION and
 // klodr/faxdrop-mcp/src/server.ts:VERSION.
-export const VERSION = "1.0.0";
+export const VERSION = "1.1.0";
 
 export interface ServerOptions {
   /**


### PR DESCRIPTION
## Summary

Bumps version to **1.1.0** across `package.json`, `server.json`, `src/server.ts:VERSION`, `package-lock.json`. Converts `CHANGELOG.md` `[Unreleased]` to `[1.1.0] - 2026-05-03`.

Pure dependency-refresh release on top of 1.0.0 — no API surface changes.

## Bumps already in main

| Package | From | To | Notes |
|---|---|---|---|
| `zod` | 4.3.6 | 4.4.2 | prod, minor — schemas pervasive in this repo |
| `nodemailer` | 8.0.6 | 8.0.7 | prod, patch |
| `eslint` | 10.2.1 | 10.3.0 | dev, minor |
| `typescript-eslint` | 8.59.0 | 8.59.1 | dev, patch |

## Test plan

- [x] `npm test` — 675/675 green
- [x] `npm run build` clean (172 KB ESM bundle)
- [x] `npm run lint` clean
- [x] `npx prettier --check .` clean
- [ ] CodeRabbit + Qodo (DeepSeek + Gemini) reviews
- [ ] Post-merge: tag `v1.1.0` from `main` HEAD signed, push tag → release workflow auto-publishes to npm with provenance