### PR TITLE
ci: add workflow_dispatch trigger to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ name: release-please
 on:
   push:
     branches: [main]
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
Adds workflow_dispatch trigger to release-please.yml so it can be re-run manually.