### PR TITLE
ci(codecov): align if_no_uploads/if_not_found with sibling MCP

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,11 @@ coverage:
         target: auto
         threshold: 0.5%
         only_pulls: false
+        # PRs that don't touch source code (CI bumps, doc-only, GitHub
+        # Actions updates) produce no coverage upload — pass instead of
+        # blocking on a missing report. Aligns with mercury/faxdrop.
+        if_no_uploads: success
+        if_not_found: success
     patch:
       default:
         # Restored to the pre-relaxation 95% target. New code in a PR
@@ -20,6 +25,8 @@ coverage:
         target: 95%
         threshold: 1.5%
         only_pulls: false
+        if_no_uploads: success
+        if_not_found: success
   ignore:
     # Doc-only / config-only PRs never touch these paths.
     - "**/*.md"


### PR DESCRIPTION
## Summary

Aligns codecov.yml on the same `if_no_uploads: success` + `if_not_found: success` flags that mercury/faxdrop already carry.

Without these flags, a PR that touches no source code (doc-only, CI bumps, GitHub Actions updates) produces no coverage upload → codecov returns "no report" and the status check fails by default. With them, codecov treats "no upload" as an explicit success — same behaviour as the sibling MCPs.

No threshold or target change; pure cohérence pass.

## Test plan
- Merge → next doc-only PR shouldn't see codecov/{patch,project} fail by default