### PR TITLE
ci(codecov): drop redundant non-code paths from ignore

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -27,14 +27,6 @@ coverage:
         only_pulls: false
         if_no_uploads: success
         if_not_found: success
-  ignore:
-    # Doc-only / config-only PRs never touch these paths.
-    - "**/*.md"
-    - "**/*.yaml"
-    - "**/*.yml"
-    - "**/*.json"
-    - ".github/**"
-
 comment:
   layout: "reach,diff,flags,files,footer"
   behavior: default


### PR DESCRIPTION
Removes the 5 standard non-code paths (`**/*.md`, `**/*.yaml`, `**/*.yml`, `**/*.json`, `.github/**`) from `coverage.ignore`.

Codecov never produces coverage for non-code paths anyway (vitest does not transpile/execute them), so listing them in `ignore` was redundant. The `if_no_uploads: success` + `if_not_found: success` flags already handle the doc-only / config-only PR case.

Mercury/faxdrop never carried these paths — bringing this repo in line with that minimalism.