### PR TITLE
ci(editorconfig): run the checker + skip indent-size

### DIFF
--- a/.editorconfig-checker.json
+++ b/.editorconfig-checker.json
@@ -1,0 +1,5 @@
+{
+  "Disable": {
+    "IndentSize": true
+  }
+}

--- a/.github/workflows/editorconfig-check.yml
+++ b/.github/workflows/editorconfig-check.yml
@@ -26,5 +26,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
-      - name: editorconfig-checker
+      - name: Install editorconfig-checker
+        # The action only adds the binary to PATH — it does not run it.
+        # The actual check is in the next step.
         uses: editorconfig-checker/action-editorconfig-checker@840e866d93b8e032123c23bac69dece044d4d84c # v2.2.0
+
+      - name: Run editorconfig-checker
+        # Honours .editorconfig + .editorconfig-checker.json at the repo
+        # root. The config disables indent-size (which trips on visual-
+        # alignment patterns in YAML continuations, JSDoc comments, and
+        # nested markdown lists) while keeping LF/UTF-8/trailing/final-
+        # newline checks.
+        run: editorconfig-checker


### PR DESCRIPTION
## Summary

Two fixes bundled — both behind the same workflow:

1. **CI workflow was silently no-op since the backport.** The `editorconfig-checker/action-editorconfig-checker@v2.2.0` action only adds the binary to PATH; it never invokes it. Adds a follow-up step that actually runs `editorconfig-checker`.

2. **Adds `.editorconfig-checker.json`** with `Disable.IndentSize=true`. The indent-size rule (`every indent must be a multiple of indent_size`) trips on visual-alignment patterns we use deliberately:
   - YAML `curl` continuations aligned under the first flag
   - JSDoc-style multi-line comments aligned under the leading word
   - Nested markdown lists with 3-space continuations

   The other rules (LF, UTF-8, `trim_trailing_whitespace`, `insert_final_newline`, `indent_style`) still apply.

## Test plan

- [x] Local `editorconfig-checker` (v3.6.1) on the branch tip exits 0
- [ ] CI `EditorConfig check` step shows `Run editorconfig-checker` in the log (proves it's no longer a no-op)
- [ ] CI passes