### PR TITLE
ci(lockfile-lint): fail-fast on unsupported lockfile shape

### DIFF
--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -52,7 +52,14 @@ jobs:
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const lock = JSON.parse(readFileSync("package-lock.json", "utf8"));
-            if (!lock.packages || typeof lock.packages !== "object") {
+            if (
+              !lock ||
+              typeof lock !== "object" ||
+              Array.isArray(lock) ||
+              !lock.packages ||
+              typeof lock.packages !== "object" ||
+              Array.isArray(lock.packages)
+            ) {
               console.error("package-lock.json format unsupported: missing top-level \"packages\" object (lockfile v1 or v2 without packages?). Regenerate with `npm install` on npm v7+.");
               process.exit(1);
             }

--- a/.github/workflows/lockfile-lint.yml
+++ b/.github/workflows/lockfile-lint.yml
@@ -52,8 +52,12 @@ jobs:
           node --input-type=module -e '
             import { readFileSync } from "node:fs";
             const lock = JSON.parse(readFileSync("package-lock.json", "utf8"));
+            if (!lock.packages || typeof lock.packages !== "object") {
+              console.error("package-lock.json format unsupported: missing top-level \"packages\" object (lockfile v1 or v2 without packages?). Regenerate with `npm install` on npm v7+.");
+              process.exit(1);
+            }
             const bad = [];
-            for (const [name, meta] of Object.entries(lock.packages ?? {})) {
+            for (const [name, meta] of Object.entries(lock.packages)) {
               if (!name || !meta || meta.link) continue;
               if (meta.resolved && !meta.resolved.startsWith("https://registry.npmjs.org/")) {
                 bad.push(name + ": resolved=" + meta.resolved);
@@ -66,7 +70,7 @@ jobs:
               console.error("package-lock preflight failed:\n" + bad.join("\n"));
               process.exit(1);
             }
-            console.log("preflight OK: " + Object.keys(lock.packages ?? {}).length + " entries");
+            console.log("preflight OK: " + Object.keys(lock.packages).length + " entries");
           '
 
       - name: Install dependencies (locked, no scripts)


### PR DESCRIPTION
## Summary

Fail-fast on unsupported lockfile shape in the preflight node script. Mirrors the same fix landed on klodr/mercury-invoicing-mcp#121 and was raised by CodeRabbit there.

## Why

The preflight previously treated a missing or non-object `packages` field as an empty set via `?? {}`, silently succeeding with "0 entries" on npm v6 (lockfileVersion 1) or any malformed lockfile that drops the top-level `packages` object. `npm ci` would then run unchecked.

Reject the unexpected shape explicitly before iterating, with a clear error message pointing at npm v7+ regeneration.

## Test plan

- [x] Local node script run against current lockfile reports `preflight OK: <N> entries`
- [ ] CI lockfile-lint workflow passes