### PR TITLE
chore(husky): pre-push gate format+lint+typecheck+test+audit

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -50,7 +50,10 @@ while read local_ref local_sha remote_ref remote_sha; do
         ;;
     esac
 
-    subject_len=${#subject}
+    # Count characters (not bytes) so emoji / accented subjects don't
+    # mis-flag. POSIX `${#var}` counts bytes in dash; `wc -m` with a
+    # UTF-8 locale counts code points portably across macOS and Linux.
+    subject_len=$(printf '%s' "$subject" | LC_ALL=en_US.UTF-8 wc -m | tr -d '[:space:]')
     if [ "$subject_len" -gt 72 ]; then
       printf '[husky] commit %s subject is %d chars (>72):\n' "$sha" "$subject_len"
       printf '        %s\n' "$subject"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -19,7 +19,7 @@ z40=0000000000000000000000000000000000000000
 #    on stdin: `<local_ref> <local_sha> <remote_ref> <remote_sha>`.
 #    Walking only HEAD would let a multi-commit push smuggle through
 #    earlier commits with a bad signature or an overlong subject.
-while read local_ref local_sha remote_ref remote_sha; do
+while read -r local_ref local_sha remote_ref remote_sha; do
   if [ "$local_sha" = "$z40" ]; then
     # Branch deletion — nothing to validate.
     continue

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -51,9 +51,10 @@ while read local_ref local_sha remote_ref remote_sha; do
     esac
 
     # Count characters (not bytes) so emoji / accented subjects don't
-    # mis-flag. POSIX `${#var}` counts bytes in dash; `wc -m` with a
-    # UTF-8 locale counts code points portably across macOS and Linux.
-    subject_len=$(printf '%s' "$subject" | LC_ALL=en_US.UTF-8 wc -m | tr -d '[:space:]')
+    # mis-flag. POSIX `${#var}` counts bytes in dash; `wc -m` with
+    # `C.UTF-8` (the universally available UTF-8 locale on Linux,
+    # macOS, and Alpine + musl-locales) counts code points portably.
+    subject_len=$(printf '%s' "$subject" | LC_ALL=C.UTF-8 wc -m | tr -d '[:space:]')
     if [ "$subject_len" -gt 72 ]; then
       printf '[husky] commit %s subject is %d chars (>72):\n' "$sha" "$subject_len"
       printf '        %s\n' "$subject"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -9,6 +9,58 @@
 
 set -e
 
+remote="$1"
+# url="$2"  # unused
+
+z40=0000000000000000000000000000000000000000
+
+# 1. Per-commit hygiene (signature + subject length) for every NEW
+#    commit in each pushed ref. Pre-push gives one ref update per line
+#    on stdin: `<local_ref> <local_sha> <remote_ref> <remote_sha>`.
+#    Walking only HEAD would let a multi-commit push smuggle through
+#    earlier commits with a bad signature or an overlong subject.
+while read local_ref local_sha remote_ref remote_sha; do
+  if [ "$local_sha" = "$z40" ]; then
+    # Branch deletion — nothing to validate.
+    continue
+  fi
+
+  if [ "$remote_sha" = "$z40" ]; then
+    # New branch — check commits not reachable from any other ref
+    # already on this remote (avoids re-checking ancestors of main).
+    range_args="$local_sha --not --remotes=$remote"
+  else
+    range_args="$remote_sha..$local_sha"
+  fi
+
+  for sha in $(git rev-list $range_args); do
+    subject=$(git log -1 --format='%s' "$sha")
+    sig=$(git log -1 --format='%G?' "$sha")
+
+    case "$sig" in
+      G|U|E)
+        # G = good signature; U = good but unknown trust;
+        # E = expired key (signature still cryptographically valid).
+        ;;
+      *)
+        printf '[husky] commit %s signature is "%s" (expected G/U/E).\n' "$sha" "$sig"
+        printf '        subject: %s\n' "$subject"
+        printf '        Configure SSH signing or set commit.gpgsign=true.\n'
+        exit 1
+        ;;
+    esac
+
+    subject_len=${#subject}
+    if [ "$subject_len" -gt 72 ]; then
+      printf '[husky] commit %s subject is %d chars (>72):\n' "$sha" "$subject_len"
+      printf '        %s\n' "$subject"
+      printf '        Shorten the subject and amend the commit.\n'
+      exit 1
+    fi
+  done
+done
+
+# 2. Tree-wide checks (run once, not per-commit).
 echo "[husky] format check..."
 npm run --silent format:check
 
@@ -23,29 +75,5 @@ npm run --silent test
 
 echo "[husky] audit (high+)..."
 npm audit --audit-level=high
-
-echo "[husky] commit hygiene (signature + subject <=72 chars)..."
-last_subject=$(git log -1 --format='%s')
-last_sig=$(git log -1 --format='%G?')
-
-case "$last_sig" in
-  G|U|E)
-    # G = good signature; U = good but unknown trust;
-    # E = expired key (signature still cryptographically valid).
-    ;;
-  *)
-    printf '[husky] last commit signature is "%s" (expected G/U/E).\n' "$last_sig"
-    printf '        Configure SSH signing or set commit.gpgsign=true.\n'
-    exit 1
-    ;;
-esac
-
-subject_len=${#last_subject}
-if [ "$subject_len" -gt 72 ]; then
-  printf '[husky] last commit subject is %d chars (>72):\n' "$subject_len"
-  printf '        %s\n' "$last_subject"
-  printf '        Shorten the subject and `git commit --amend`.\n'
-  exit 1
-fi
 
 echo "[husky] all checks passed -> pushing"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Pre-push gate.
+#
+# Runs the same checks GitHub Actions enforces, locally and BEFORE the
+# push lands on origin. Failure blocks the push.
+#
+# Bypass with `git push --no-verify` ONLY when the hook is wrong
+# (rare). The bypass is recorded in the local reflog.
+
+set -e
+
+echo "[husky] format check..."
+npm run --silent format:check
+
+echo "[husky] lint..."
+npm run --silent lint
+
+echo "[husky] typecheck..."
+npm run --silent typecheck
+
+echo "[husky] tests..."
+npm run --silent test
+
+echo "[husky] audit (high+)..."
+npm audit --audit-level=high
+
+echo "[husky] commit hygiene (signature + subject <=72 chars)..."
+last_subject=$(git log -1 --format='%s')
+last_sig=$(git log -1 --format='%G?')
+
+case "$last_sig" in
+  G|U|E)
+    # G = good signature; U = good but unknown trust;
+    # E = expired key (signature still cryptographically valid).
+    ;;
+  *)
+    printf '[husky] last commit signature is "%s" (expected G/U/E).\n' "$last_sig"
+    printf '        Configure SSH signing or set commit.gpgsign=true.\n'
+    exit 1
+    ;;
+esac
+
+subject_len=${#last_subject}
+if [ "$subject_len" -gt 72 ]; then
+  printf '[husky] last commit subject is %d chars (>72):\n' "$subject_len"
+  printf '        %s\n' "$last_subject"
+  printf '        Shorten the subject and `git commit --amend`.\n'
+  exit 1
+fi
+
+echo "[husky] all checks passed -> pushing"

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint-config-prettier": "^10.1.8",
         "fast-check": "^4.7.0",
         "gaxios": "^7.1.4",
+        "husky": "^9.1.7",
         "lockfile-lint": "^5.0.0",
         "prettier": "^3.8.3",
         "tsup": "^8.5.1",
@@ -3990,6 +3991,22 @@
       },
       "engines": {
         "node": ">= 14"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/iconv-lite": {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "eslint src",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "prepare": "husky",
     "prepublishOnly": "npm run build",
     "version": "node scripts/sync-version.mjs && git add server.json src/server.ts"
   },
@@ -79,6 +80,7 @@
     "eslint-config-prettier": "^10.1.8",
     "fast-check": "^4.7.0",
     "gaxios": "^7.1.4",
+    "husky": "^9.1.7",
     "lockfile-lint": "^5.0.0",
     "prettier": "^3.8.3",
     "tsup": "^8.5.1",


### PR DESCRIPTION
## What

Adds a Husky 9 pre-push hook that runs locally the same checks GitHub
Actions enforces, BEFORE the push lands on origin.

## Checks

- `npm run format:check` — prettier
- `npm run lint` — eslint
- `npm run typecheck` — `tsc --noEmit`
- `npm test` — vitest
- `npm audit --audit-level=high`
- commit hygiene: signature `G`/`U`/`E` + subject ≤72 chars

## Why

Cuts the round-trip "push → CI fails → re-push" by catching format,
lint, typecheck, and test regressions in the local terminal in seconds.
Standard pattern across modern TS-ESM repos.

## Bypass

`git push --no-verify` if the hook is wrong (rare). The bypass is
recorded in the local reflog.

## Setup for new clones

`npm install` runs the new `prepare` script, which auto-registers
the hook. No extra steps.