### PR TITLE
chore(eslint): add eslint-plugin-promise (flat/recommended)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,6 +3,7 @@
 
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
+import promise from "eslint-plugin-promise";
 import prettier from "eslint-config-prettier";
 
 const __dirname = import.meta.dirname;
@@ -22,6 +23,7 @@ export default tseslint.config(
   },
   js.configs.recommended,
   ...tseslint.configs.strict,
+  promise.configs["flat/recommended"],
   prettier,
   {
     languageOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@vitest/coverage-v8": "^4.1.5",
         "eslint": "^10.3.0",
         "eslint-config-prettier": "^10.1.8",
+        "eslint-plugin-promise": "^7.3.0",
         "fast-check": "^4.7.0",
         "gaxios": "^7.1.4",
         "husky": "^9.1.7",
@@ -3194,6 +3195,25 @@
       },
       "peerDependencies": {
         "eslint": ">=7.0.0"
+      }
+    },
+    "node_modules/eslint-plugin-promise": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-7.3.0.tgz",
+      "integrity": "sha512-6uGiOR0INuujr6PEQmeSSP7GbIMJ/ebEXXiEzb/nOj68LknH5Pxzb/AbZivmr6VE6TkTE8rTjRK9zhKpK6HsRA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.4.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-scope": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@vitest/coverage-v8": "^4.1.5",
     "eslint": "^10.3.0",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-promise": "^7.3.0",
     "fast-check": "^4.7.0",
     "gaxios": "^7.1.4",
     "husky": "^9.1.7",


### PR DESCRIPTION
## What

Adds [`eslint-plugin-promise`](https://github.com/eslint-community/eslint-plugin-promise)
in `flat/recommended` mode to the ESLint config.

## Impact

Zero anomalies on `src/`. The rules complement what `tseslint`'s
`recommendedTypeChecked` already enforces (`no-floating-promises`,
`await-thenable`, `no-misused-promises`) with shape-level checks
(`no-callback-in-promise`, `param-names`, `no-return-wrap`, etc.).

## Why

Cheap upgrade to the lint baseline. Zero churn today, catches
common Promise foot-guns in future contributions.

## Plan context

First of four planned PRs aligning the ESLint config across klodr/* MCPs:
1. **eslint-plugin-promise** — this PR
2. `tseslint.configs.strict`
3. `tseslint.configs.strictTypeChecked`
4. `eslint-plugin-import-x`