### PR TITLE
chore(eslint): switch to tseslint.configs.strict

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -21,7 +21,7 @@ export default tseslint.config(
     ],
   },
   js.configs.recommended,
-  ...tseslint.configs.recommendedTypeChecked,
+  ...tseslint.configs.strict,
   prettier,
   {
     languageOptions: {

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -212,6 +212,10 @@ export async function runServer(opts: RunServerOpts): Promise<void> {
     try {
       await authenticate({
         oauth2Client,
+        // The mode dispatch above guarantees `oauthCallbackUrl` is set
+        // when entering the `auth` branch, but TS can't follow the
+        // narrowing through the dispatch table.
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         oauthCallbackUrl: oauthCallbackUrl!,
         scopes,
         credentialsPath: CREDENTIALS_PATH,

--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -58,6 +58,10 @@ export function registerDownloadTools(
 
         let content: string;
         if (format === "eml") {
+          // `rawResponse` is fetched only on the `eml` branch above,
+          // so it is defined here. TS's narrowing across the if/else
+          // doesn't reach the parallel fetch.
+          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           content = Buffer.from(rawResponse!.data.raw || "", "base64url").toString("utf-8");
         } else {
           const emailContent = extractEmailContent(

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -147,6 +147,9 @@ export function registerMessageTools(
         messages.map(async (msg) => {
           const detail = await gmail.users.messages.get({
             userId: "me",
+            // Gmail's `messages.list` always returns `id` on each item;
+            // the type marks it optional out of an abundance of caution.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             id: msg.id!,
             format: "metadata",
             metadataHeaders: ["Subject", "From", "Date"],

--- a/src/tools/threads.ts
+++ b/src/tools/threads.ts
@@ -153,6 +153,9 @@ export function registerThreadTools(
         threads.map(async (thread) => {
           const detail = await gmail.users.threads.get({
             userId: "me",
+            // Gmail's `threads.list` always returns `id` on each item;
+            // the type marks it optional out of an abundance of caution.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             id: thread.id!,
             format: "metadata",
             metadataHeaders: ["Subject", "From", "Date"],
@@ -213,6 +216,9 @@ export function registerThreadTools(
           threads.map(async (thread) => {
             const detail = await gmail.users.threads.get({
               userId: "me",
+              // Gmail's `threads.list` always returns `id` on each item;
+              // the type marks it optional out of an abundance of caution.
+              // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
               id: thread.id!,
               format: "metadata",
               metadataHeaders: ["Subject", "From", "Date"],
@@ -252,6 +258,9 @@ export function registerThreadTools(
         threads.map(async (thread) => {
           const threadDetail = await gmail.users.threads.get({
             userId: "me",
+            // Gmail's `threads.list` always returns `id` on each item;
+            // the type marks it optional out of an abundance of caution.
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
             id: thread.id!,
             format: "full",
           });


### PR DESCRIPTION
## What

Swap the ESLint preset from `recommendedTypeChecked` to
`strict` in the typescript-eslint chain.

## Impact (6 anomalies fixed)

6× `no-non-null-assertion` on `msg.id!` / `thread.id!` / `rawResponse!.data.raw` / `oauthCallbackUrl!` — Gmail API and internal control-flow guarantees the value is set, but TS narrowing can't see through the optional types or the dispatch table. Each fix is a one-line `// eslint-disable-next-line` with a comment naming the runtime invariant.

## Why

`strict` enables a curated set of high-value rules over `recommendedTypeChecked`:
`no-confusing-non-null-assertion`, `no-extraneous-class`, `no-invalid-void-type`,
`no-meaningless-void-operator`, `no-non-null-asserted-nullish-coalescing`,
`no-this-alias`, `no-useless-empty-export`, `prefer-literal-enum-member`,
`unified-signatures`, etc.

## Plan context

Second of four planned PRs aligning ESLint across klodr/* MCPs:
1. (in review) `eslint-plugin-promise` (#132)
2. **`tseslint.configs.strict`** — this PR
3. `tseslint.configs.strictTypeChecked`
4. `eslint-plugin-import-x`