### PR TITLE
ci: factor ci.yml via klodr/.github composite actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,13 @@ jobs:
       # failed test runs still upload their JUnit report — that's the
       # case where the flaky-test dashboard is most useful. `!cancelled()`
       # keeps us from pushing phantom results for a cancelled workflow.
+      #
+      # `continue-on-error: true` at the step level catches wrapper /
+      # runtime failures that bypass codecov-action's `fail_ci_if_error`
+      # input — together they make the analytics upload truly best-effort
+      # so a transient codecov outage cannot BLOCK the merge gate.
       - if: ${{ always() && matrix.node == '22' && !cancelled() }}
+        continue-on-error: true
         uses: klodr/.github/.github/actions/codecov-test-analytics@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
         with:
           slug: klodr/gmail-mcp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,28 +14,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Job display names (`Lint & Format`, `Build & Test (Node 22)`,
+# `Build & Test (Node 24)`) are pinned by the main branch ruleset's
+# required-status-checks list. Any rename here must be matched by a
+# ruleset update or the merge gate stays BLOCKED.
 jobs:
   lint:
     name: Lint & Format
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-
-      - name: Setup Node 22
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: klodr/.github/.github/actions/setup-node-mcp@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
         with:
           node-version: "22"
-          cache: "npm"
 
-      - name: Install dependencies
-        run: npm ci
-
-      - name: ESLint
-        run: npm run lint
-
-      - name: Prettier (check)
-        run: npm run format:check
+      - uses: klodr/.github/.github/actions/lint-format@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
 
   build:
     name: Build & Test (Node ${{ matrix.node }})
@@ -54,17 +46,9 @@ jobs:
       matrix:
         node: ["22", "24"]
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.0
-
-      - name: Setup Node ${{ matrix.node }}
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - uses: klodr/.github/.github/actions/setup-node-mcp@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
         with:
           node-version: ${{ matrix.node }}
-          cache: "npm"
-
-      - name: Install dependencies
-        run: npm ci
 
       - name: Build
         run: npm run build
@@ -77,46 +61,20 @@ jobs:
         if: matrix.node == '22'
         run: npm run test:coverage
 
-      # Pre-mark the Codecov signing key as ultimate-trust so the
-      # subsequent `gpg --verify` inside codecov-action stops emitting
-      # "WARNING: This key is not certified with a trusted signature!".
-      # Cosmetic but misleading on a supply-chain audit log.
-      - name: Pre-trust Codecov GPG signing key
-        if: matrix.node == '22'
-        run: echo "27034E7FDB850E0BBC2C62FF806BB28AED779869:6:" | gpg --import-ownertrust
-
-      - name: Upload coverage to Codecov
-        if: matrix.node == '22'
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      - if: matrix.node == '22'
+        uses: klodr/.github/.github/actions/codecov-upload@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
         with:
-          fail_ci_if_error: true
           slug: klodr/gmail-mcp
-          # OIDC-based upload — works in Dependabot PR context too,
-          # where `secrets.CODECOV_TOKEN` is unavailable. Tokens are
-          # still scoped per-upload; OIDC just removes the long-lived
-          # secret from the round-trip.
-          use_oidc: true
-          # Upload BOTH the lcov rollup AND the v8-native JSON report.
-          # The lcov upload satisfies the basic coverage check; the
-          # JSON carries branch-level detail codecov uses to compute
-          # accurate indirect-changes (without it, codecov reports
-          # phantom regressions on files the PR doesn't touch).
-          # `disable_search: true` skips the multi-language probe that
-          # would otherwise warn about missing xcrun / gcov / coverage.py.
-          files: ./coverage/lcov.info,./coverage/coverage-final.json
-          disable_search: true
 
-      - name: Upload test results to Codecov (Test Analytics)
-        # Explicit `always()` bypasses the implicit `success()` check so
-        # failed test runs still upload their JUnit report — that's the
-        # case where the flaky-test dashboard is most useful. `!cancelled()`
-        # keeps us from pushing phantom results for a cancelled workflow.
-        if: ${{ always() && matrix.node == '22' && !cancelled() }}
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+      # Explicit `always()` bypasses the implicit `success()` check so
+      # failed test runs still upload their JUnit report — that's the
+      # case where the flaky-test dashboard is most useful. `!cancelled()`
+      # keeps us from pushing phantom results for a cancelled workflow.
+      - if: ${{ always() && matrix.node == '22' && !cancelled() }}
+        uses: klodr/.github/.github/actions/codecov-test-analytics@cfc709297722fd29bb9e66a3d0f13529ba4d6295 # main @ 2026-05-10
         with:
-          report_type: test_results
+          slug: klodr/gmail-mcp
           files: ./test-results.junit.xml
-          fail_ci_if_error: false
-          slug: klodr/gmail-mcp
-          use_oidc: true
-          disable_search: true
+          # Test Analytics is best-effort — the dashboard is informational
+          # and a transient codecov outage shouldn't BLOCK the merge gate.
+          fail-on-error: "false"


### PR DESCRIPTION
Migrate ci.yml to klodr/.github composite actions. Mirrors faxdrop PR #133 and mercury PR #142.