### PR TITLE
fix: use named import for nodemailer createTransport

### DIFF
--- a/src/utl.ts
+++ b/src/utl.ts
@@ -3,7 +3,7 @@ import os from "os";
 import path from "path";
 import { randomBytes } from "crypto";
 import emailAddresses from "email-addresses";
-import nodemailer from "nodemailer";
+import { createTransport } from "nodemailer";
 
 // Env-var names for the two jails. Hoisted to constants so a future
 // rename is a single-line change and the names cannot drift between
@@ -541,7 +541,7 @@ export async function createEmailWithNodemailer(
   });
 
   // Create a nodemailer transporter (we won't actually send, just generate the message)
-  const transporter = nodemailer.createTransport({
+  const transporter = createTransport({
     streamTransport: true,
     newline: "unix",
     buffer: true,


### PR DESCRIPTION
## Summary

Switch `nodemailer` import from default to named.

The current `import nodemailer from "nodemailer"` triggers an ESLint warning because `createTransport` is also a named export — the default + named-as-property pattern is ambiguous. Using the named import directly removes the warning and matches the documented usage.

## Diff

```diff
-import nodemailer from "nodemailer";
+import { createTransport } from "nodemailer";
...
-  const transporter = nodemailer.createTransport({
+  const transporter = createTransport({
```

Single call site (src/utl.ts L544) — no other `nodemailer.<x>` accesses in the codebase. Behavior unchanged.