### PR TITLE
ci: bump github-script v9 + migrate to client-id

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -98,6 +98,14 @@ jobs:
         with:
           client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
+          # Scope the minted token to the strict set release-please needs
+          # (per googleapis/release-please-action docs). Without these,
+          # the token inherits every permission granted to the app
+          # installation — too broad for a workflow whose only job is
+          # opening release PRs and tagging releases.
+          permission-contents: write
+          permission-issues: write
+          permission-pull-requests: write
 
       - name: release-please
         if: github.event_name == 'workflow_dispatch' || steps.checks-gate.outputs.ready == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Gate until all required upstream workflows succeeded for this SHA
         id: checks-gate
         if: github.event_name == 'workflow_run'
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.0.1
+        uses: actions/github-script@d746ffe35508b1917358783b479e04febd2b8f71 # v9.0.0
         with:
           script: |
             const required = ["CI", "CodeQL Advanced", "Docker build"];
@@ -96,7 +96,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch' || steps.checks-gate.outputs.ready == 'true'
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          client-id: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
           private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
       - name: release-please


### PR DESCRIPTION
## Summary

Two updates to `.github/workflows/release-please.yml`:

1. Bump `actions/github-script` from `v7.0.1` to `v9.0.0` — Node 20 deprecated June 2026
2. Migrate `actions/create-github-app-token` from `app-id` (deprecated input) to `client-id` — using the new `RELEASE_PLEASE_CLIENT_ID` secret

The `RELEASE_PLEASE_CLIENT_ID` secret has been provisioned at the org/repo level; `RELEASE_PLEASE_APP_PRIVATE_KEY` remains unchanged.

## Test plan

- [ ] CI green
- [ ] CodeRabbit review APPROVED
- [ ] Workflow exercised on next release-please run after merge
