### PR TITLE
ci(dependabot): use chore(deps) prefix for Conventional Commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,11 +23,13 @@ updates:
       production-dependencies:
         dependency-type: "production"
     commit-message:
-      # No `include: "scope"` — it would duplicate the type in the
-      # prefix ("deps(deps): …" / "deps-dev(deps-dev): …") since we
-      # already encode prod vs dev in `prefix` / `prefix-development`.
-      prefix: "deps"
-      prefix-development: "deps-dev"
+      # Conventional Commits: type=chore, scope=deps|deps-dev. The pre-merge
+      # title check enforces the type vocabulary (feat/fix/docs/chore/refactor/
+      # test/ci/build/perf/revert) — `deps:` and `deps-dev:` are not in the
+      # allowed list. No `include: "scope"`: it would chain the package name
+      # as a second scope ("chore(deps)(react): …"), which the linter rejects.
+      prefix: "chore(deps)"
+      prefix-development: "chore(deps-dev)"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
## Why

The pre-merge title check on klodr/* (`.coderabbit.yaml` `pre_merge_checks.title.mode = error`)
enforces Conventional Commits with type ∈ {feat, fix, docs, chore, refactor, test, ci, build, perf, revert}.

Dependabot's npm groups currently emit titles like:
- `deps-dev: bump the dev-dependencies group across 1 directory with 2 updates`
- `deps: bump production-dependencies`

Both `deps:` and `deps-dev:` are NOT in the allowed type list, so every npm
Dependabot PR fails the title check until renamed by hand.

## Fix

Change the `commit-message.prefix` for the npm ecosystem to wrap the existing
prod/dev info inside a `chore(...)` Conventional Commits scope:

- `prefix: "deps"` → `prefix: "chore(deps)"`
- `prefix-development: "deps-dev"` → `prefix-development: "chore(deps-dev)"`

Generated titles become e.g. `chore(deps-dev): bump the dev-dependencies …`
which satisfies the gate.

`include: "scope"` is intentionally NOT set — it would chain the package
name as a second scope (`chore(deps)(react): …`), which the linter rejects.

## Notes

- Identical change applied across all 5 klodr/* repos with this dependabot.yml
  pattern (gmail-mcp, faxdrop-mcp, mercury-invoicing-mcp, relayfi-mcp,
  eslint-plugin-mcp-security).
- github-actions ecosystem is unchanged — `ci:` is already a valid type.