### PR TITLE
ci(bundle-analysis): run on Dependabot PRs to satisfy required check

### DIFF
--- a/.github/workflows/bundle-analysis.yml
+++ b/.github/workflows/bundle-analysis.yml
@@ -33,7 +33,6 @@ jobs:
   bundle-analysis:
     name: Bundle Analysis
     runs-on: ubuntu-latest
-    if: ${{ github.actor != 'dependabot[bot]' }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
The `bundle-analysis.yml` workflow had `if: github.actor != 'dependabot[bot]'`
on the `bundle-analysis` job. The job is in the required status checks of the
`main` branch ruleset (and posts `codecov/bundles` which is also required).

Combined effect: every Dependabot PR ended up in `BLOCKED` merge state with
`Bundle Analysis = SKIPPED` and `codecov/bundles` missing from the rollup.
Auto-merge could never fire, even with checks otherwise green.

`codecov/bundles` is informational by default (no `codecov.yml` configures
a strict threshold), so running the workflow on Dependabot PRs uploads the
bundle data and the check posts SUCCESS without fail-on-growth risk.

Mirrors the same fix applied across the 3 MCP repos that have this workflow
(gmail, faxdrop, mercury).