### PR TITLE
fix(ci): gate auto-merge caller on bot login before passing secrets

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -22,6 +22,11 @@ permissions:
 
 jobs:
   call:
+    # Defense-in-depth: gate secrets at the caller before they're passed to
+    # the reusable workflow. The reusable also has its own bot-login filter,
+    # but matching here means the secrets are only forwarded for the one
+    # event that needs them, and human/dependabot PRs short-circuit early.
+    if: ${{ github.event.pull_request.user.login == 'release-please-app[bot]' }}
     uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@a44b6ecf0876fde506bbf289b69a3da1efc5f5d1
     secrets:
       RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}


### PR DESCRIPTION
Mirrors klodr/eslint-plugin-security-mcp#12 (CR finding).

The `auto-merge-release-please.yml` caller currently invokes the reusable
workflow on every PR event and forwards `RELEASE_PLEASE_APP_PRIVATE_KEY`
to it. The reusable does its own bot-login filter internally, but adding
the same `if:` guard at the caller lets human/dependabot PRs short-circuit
before any secret is forwarded — defense-in-depth.

```yaml
jobs:
  call:
    if: ${{ github.event.pull_request.user.login == 'release-please-app[bot]' }}
    uses: …
```