### PR TITLE
chore: add pinact config + actions-pinned CI gate

### DIFF
--- a/.github/workflows/actions-pinned.yml
+++ b/.github/workflows/actions-pinned.yml
@@ -23,5 +23,6 @@ jobs:
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
           version: v3.9.2
+          skip_push: "true"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/actions-pinned.yml
+++ b/.github/workflows/actions-pinned.yml
@@ -1,0 +1,27 @@
+name: Actions pinned
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - "pinact.yaml"
+
+permissions: {}
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
+        with:
+          version: v3.9.2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/pinact.yaml
+++ b/pinact.yaml
@@ -1,0 +1,7 @@
+version: 3
+
+files:
+  - pattern: ".github/workflows/*.yml"
+  - pattern: ".github/workflows/*.yaml"
+  - pattern: ".github/actions/*/action.yml"
+  - pattern: ".github/actions/*/action.yaml"


### PR DESCRIPTION
## Summary

Adds:

- `pinact.yaml` — config (default scope: workflows + composite actions)
- `.github/workflows/actions-pinned.yml` — required CI check that runs `pinact run --check` on every PR touching workflows

`pinact run --check` already passes — all current SHA refs in this repo were already pinned.

## Tooling SHAs (verified live via `gh api`)

- `actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683` — v4.2.2
- `suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6` — v2.0.0
- pinact CLI version `v3.9.2`

## Test plan

- [x] `pinact run --check` exits 0 locally
- [ ] CI green