### PR TITLE
fix(lint): drain CR findings + valid globs syntax

### DIFF
--- a/.github/workflows/lint-yaml-md.yml
+++ b/.github/workflows/lint-yaml-md.yml
@@ -12,8 +12,3 @@ permissions:
 jobs:
   lint:
     uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@26b7f93b5a39c544f4414ada76cd2c79d9732bbd
-    with:
-      # Exclude CHANGELOG.md (release-please format uses dash bullets,
-      # different from our `*` style enforced by markdownlint MD004) and
-      # generated dirs.
-      markdownlint-globs: "**/*.md #node_modules #coverage #dist #CHANGELOG.md"

--- a/.github/workflows/lint-yaml-md.yml
+++ b/.github/workflows/lint-yaml-md.yml
@@ -12,3 +12,14 @@ permissions:
 jobs:
   lint:
     uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@26b7f93b5a39c544f4414ada76cd2c79d9732bbd
+    with:
+      # markdownlint-cli2-action splits globs by newline (NOT space).
+      # Pass each pattern on its own line; `#prefix` excludes.
+      # The config's `ignores` array is only honored when invoked
+      # without explicit globs, hence we re-list exclusions here.
+      markdownlint-globs: |
+        **/*.md
+        #CHANGELOG.md
+        #node_modules
+        #coverage
+        #dist


### PR DESCRIPTION
Follow-up to Option C: applies the 3 lint-pack fixes that landed on the branch AFTER auto-merge fired. Drops invalid `markdownlint-globs` (action splits by newline not space), cascades CR findings (yamllint EN header, lint:md DRY, type-enum reduced to 8 standard types).