### PR TITLE
fix(pinact): dot-prefix config + recursive action globs

### DIFF
--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -3,5 +3,5 @@ version: 3
 files:
   - pattern: ".github/workflows/*.yml"
   - pattern: ".github/workflows/*.yaml"
-  - pattern: ".github/actions/*/action.yml"
-  - pattern: ".github/actions/*/action.yaml"
+  - pattern: ".github/actions/**/action.yml"
+  - pattern: ".github/actions/**/action.yaml"


### PR DESCRIPTION
Two CR findings on pinact config (cascaded from klodr/mercury-invoicing-mcp #159):

1. **Recursive globs** for nested composite actions: `.github/actions/*/action.yml` → `.github/actions/**/action.yml` (future-proof).
2. **Rename to `.pinact.yaml`** — pinact only auto-discovers dot-prefixed config names. The current `pinact.yaml` is silently ignored on every run.

Net: scanner now actually uses our config file.