### PR TITLE
fix(ci): repin reusable auto-merge to a reachable SHA

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -27,7 +27,7 @@ jobs:
     # but matching here means the secrets are only forwarded for the one
     # event that needs them, and human/dependabot PRs short-circuit early.
     if: ${{ github.event.pull_request.user.login == 'klodr-release-please[bot]' }}
-    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@a44b6ecf0876fde506bbf289b69a3da1efc5f5d1
+    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@5a3a5093bc93bc2a682b5a0cb438149af2516f4c
     secrets:
       RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
       RELEASE_PLEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}


### PR DESCRIPTION
The current SHA pin in the caller is orphan (not reachable from main on klodr/.github), so GitHub Actions returns 'workflow was not found' on every PR. Repinning to a SHA that's an ancestor of klodr/.github main.