### PR TITLE
chore(lint-staged): add prettier --write to all globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,16 +108,20 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,mts}": [
-      "eslint --max-warnings=0 --no-warn-ignored"
+      "eslint --max-warnings=0 --no-warn-ignored",
+      "prettier --write"
     ],
     "*.{json,jsonc,json5}": [
-      "eslint --max-warnings=0 --no-warn-ignored"
+      "eslint --max-warnings=0 --no-warn-ignored",
+      "prettier --write"
     ],
     "*.{yml,yaml}": [
-      "yamllint"
+      "yamllint",
+      "prettier --write"
     ],
     "*.md": [
-      "markdownlint-cli2"
+      "markdownlint-cli2",
+      "prettier --write"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -108,20 +108,20 @@
   },
   "lint-staged": {
     "*.{ts,tsx,js,mjs,cjs,mts}": [
-      "eslint --max-warnings=0 --no-warn-ignored",
-      "prettier --write"
+      "prettier --write",
+      "eslint --max-warnings=0 --no-warn-ignored"
     ],
     "*.{json,jsonc,json5}": [
-      "eslint --max-warnings=0 --no-warn-ignored",
-      "prettier --write"
+      "prettier --write",
+      "eslint --max-warnings=0 --no-warn-ignored"
     ],
     "*.{yml,yaml}": [
-      "yamllint",
-      "prettier --write"
+      "prettier --write",
+      "yamllint"
     ],
     "*.md": [
-      "markdownlint-cli2",
-      "prettier --write"
+      "prettier --write",
+      "markdownlint-cli2"
     ]
   }
 }


### PR DESCRIPTION
Catches prettier issues at commit time (lint-staged auto-fix + re-stage) instead of CI fail. Prevents the kind of late-stage prettier-only fix cycle that just happened on PR #171.