### PR TITLE
fix(pre-commit): call ./node_modules/.bin/lint-staged directly

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -9,21 +9,17 @@
 #      both from PATH and from the local node_modules/.bin. Otherwise
 #      lint-staged dies mid-commit with a cryptic
 #      "<tool>: command not found".
-#   2. Run `lint-staged` via `npx --no` so a stale/missing node_modules
-#      fails loudly instead of silently fetching an unpinned version.
+#   2. Run `lint-staged` via the local binary path (NOT npx). Some npm
+#      versions still attempt a registry fetch on `npx --no` despite
+#      the --no flag; calling the binary directly removes any
+#      ambiguity and guarantees the lockfile-pinned version is what
+#      runs. Fails loudly if node_modules is stale or missing.
 #
 # Tooling used by the klodr/* lint-staged configs:
 #   - yamllint  → provided by the npm package `yaml-lint` (devDep) which
 #                 installs a `yamllint` binary at
 #                 node_modules/.bin/yamllint. Falls back to a system
 #                 install (brew install yamllint) if you prefer.
-#
-# If any of these are missing, print install hints and continue. We do
-# not exit non-zero on missing tooling because lint-staged will skip
-# the YAML hook silently if no YAML files are staged, and we don't
-# want every commit on every machine to be blocked on a tool that may
-# not be needed for this particular commit. The hook itself will fail
-# loudly when YAML is actually staged and the tool is missing.
 
 missing=""
 for tool in yamllint; do
@@ -34,10 +30,21 @@ for tool in yamllint; do
 done
 
 if [ -n "$missing" ]; then
-  printf '[husky] WARN — missing tooling (PATH + ./node_modules/.bin):%s\n' "$missing"
-  printf '[husky]   npm install                 (preferred — provided as yaml-lint devDep)\n'
-  printf '[husky]   macOS:  brew install%s\n' "$missing"
-  printf '[husky]   Linux:  pip install --user%s\n' "$missing"
+  printf '[husky] WARN — missing tooling (PATH + ./node_modules/.bin):%s
+' "$missing"
+  printf '[husky]   npm install                 (preferred — provided as yaml-lint devDep)
+'
+  printf '[husky]   macOS:  brew install%s
+' "$missing"
+  printf '[husky]   Linux:  pip install --user%s
+' "$missing"
 fi
 
-npx --no -- lint-staged
+if [ ! -x "./node_modules/.bin/lint-staged" ]; then
+  printf '[husky] lint-staged is not installed locally.
+' >&2
+  printf '        Run `npm install` (or `npm ci`) and re-commit.
+' >&2
+  exit 1
+fi
+./node_modules/.bin/lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,24 +5,22 @@
 # Copy verbatim into each consumer repo's .husky/pre-commit.
 #
 # Two responsibilities:
-#   1. Warn (non-blocking) when a CLI invoked by lint-staged is missing
-#      both from PATH and from the local node_modules/.bin. Otherwise
-#      lint-staged dies mid-commit with a cryptic
-#      "<tool>: command not found".
-#   2. Run `lint-staged` via the local binary path (NOT npx). Some npm
+#   1. Refuse the commit when a CLI invoked by lint-staged is missing
+#      both from PATH and from ./node_modules/.bin. lint-staged would
+#      otherwise die mid-commit with a cryptic "<tool>: command not
+#      found"; refuse upfront instead.
+#   2. Run lint-staged via the local binary path (NOT npx). Some npm
 #      versions still attempt a registry fetch on `npx --no` despite
-#      the --no flag; calling the binary directly removes any
-#      ambiguity and guarantees the lockfile-pinned version is what
-#      runs. Fails loudly if node_modules is stale or missing.
+#      the --no flag; calling the binary directly removes any ambiguity
+#      and guarantees the lockfile-pinned version is what runs.
 #
-# Tooling used by the klodr/* lint-staged configs:
-#   - yamllint  → provided by the npm package `yaml-lint` (devDep) which
-#                 installs a `yamllint` binary at
-#                 node_modules/.bin/yamllint. Falls back to a system
-#                 install (brew install yamllint) if you prefer.
+# A consumer repo whose lint-staged or scripts need more system tools
+# may extend REQUIRED_TOOLS in its own .husky/pre-commit copy.
+
+REQUIRED_TOOLS="yamllint"
 
 missing=""
-for tool in yamllint; do
+for tool in $REQUIRED_TOOLS; do
   if ! command -v "$tool" >/dev/null 2>&1 \
      && [ ! -x "./node_modules/.bin/$tool" ]; then
     missing="$missing $tool"
@@ -30,21 +28,12 @@ for tool in yamllint; do
 done
 
 if [ -n "$missing" ]; then
-  printf '[husky] WARN — missing tooling (PATH + ./node_modules/.bin):%s
-' "$missing"
-  printf '[husky]   npm install                 (preferred — provided as yaml-lint devDep)
-'
-  printf '[husky]   macOS:  brew install%s
-' "$missing"
-  printf '[husky]   Linux:  pip install --user%s
-' "$missing"
+  printf '[husky] ERROR — required tooling missing:%s\n' "$missing" >&2
+  exit 1
 fi
 
 if [ ! -x "./node_modules/.bin/lint-staged" ]; then
-  printf '[husky] lint-staged is not installed locally.
-' >&2
-  printf '        Run `npm install` (or `npm ci`) and re-commit.
-' >&2
+  printf '[husky] lint-staged is not installed locally — run npm install.\n' >&2
   exit 1
 fi
 ./node_modules/.bin/lint-staged


### PR DESCRIPTION
Drop `npx --no -- lint-staged` in favour of the lockfile-pinned binary path. `npx --no` is supposed to refuse the registry fetch when the package is missing, but the behaviour is not guaranteed across all npm versions — Codex flagged a case where cancel-on-missing does not fire deterministically. Calling the binary directly removes the ambiguity and guarantees what runs is what package-lock.json pins.

Mirrors the canonical klodr/.github template (PR #22).