### PR TITLE
ci: add leak-detect caller workflow

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -21,6 +21,12 @@ concurrency:
 jobs:
   leak-detect:
     name: Leak detect
+    # Skip on PRs from forks: GitHub does not expose repository secrets
+    # to `pull_request` runs whose head repo differs from the base, so
+    # the GitHub App credentials would be empty and the job would hard-
+    # fail as a required check. Leak scanning of fork PRs is enforced
+    # post-merge by the maintainer-side push trigger on main.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@a2618fb7c675a9f6bbbd68f0f957dd5ffa1b5c10
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}

--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -21,6 +21,7 @@ concurrency:
 jobs:
   leak-detect:
     name: Leak detect
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@212a01a8716da2747951ec9e1ff88744c557e8b4
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@a2618fb7c675a9f6bbbd68f0f957dd5ffa1b5c10
     secrets:
-      leak-detect-pat: ${{ secrets.LEAK_DETECT_PAT }}
+      leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
+      leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -1,0 +1,26 @@
+name: Leak detect (private patterns)
+
+# Scans the PR diff plus PR metadata (title, body, commit messages)
+# against the centrally-maintained pattern set. Catches accidental
+# disclosure of internal hostnames, infra slugs, PII regexes, etc.
+# that the public OSS scanners (gitleaks) don't know about.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  leak-detect:
+    name: Leak detect
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@212a01a8716da2747951ec9e1ff88744c557e8b4
+    secrets:
+      leak-detect-pat: ${{ secrets.LEAK_DETECT_PAT }}


### PR DESCRIPTION
## Summary

Wires this repo into the central reusable leak-detect workflow on `klodr/.github`. Pinned to the latest SHA where the reusable workflow lives on main.

Runs on every `pull_request` (opened/synchronize/reopened/edited) and scans both the PR diff **and** PR metadata (title, body, commit messages) against the centrally-maintained pattern set, before merge.

This complements the public OSS scanners (gitleaks) by catching internal hostnames, infra slugs and PII regex shapes that gitleaks doesn't ship rules for.

## Required setup

The reusable workflow consumes a fine-grained PAT (`LEAK_DETECT_PAT`) scoped read-only on the central patterns repo. The repo secret must be configured for this caller to succeed.

## Test plan

- [ ] CI passes after the PAT secret is configured
- [ ] Smoke test: open a follow-up PR introducing a known fixture string; confirm the scanner fails closed