### PR TITLE
fix(scripts): tolerate trailing release-please marker on VERSION line

### DIFF
--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -51,14 +51,19 @@ export function syncVersion(rootDir) {
   }
   const v = pkg.version;
 
-  // 1. server.json
+  // 1. Prepare the new server.json payload (do NOT write yet — see
+  // step 3 for the atomic write phase. Writing server.json before
+  // step 2 validates src/server.ts would leave the repo in a
+  // partially bumped state if step 2 throws — server.json shipped
+  // forward, src/server.ts still on the old literal — which then
+  // smuggles a mismatched-metadata release into npm).
   const serverJsonPath = join(rootDir, "server.json");
   const server = JSON.parse(readFileSync(serverJsonPath, "utf8"));
   server.version = v;
   for (const p of server.packages ?? []) {
     if (p.identifier === pkg.name) p.version = v;
   }
-  writeFileSync(serverJsonPath, JSON.stringify(server, null, 2) + "\n");
+  const serverJsonOutput = JSON.stringify(server, null, 2) + "\n";
 
   // 2. src/server.ts — the exported `VERSION` constant (mirrors mercury / faxdrop)
   const tsPath = join(rootDir, "src", "server.ts");
@@ -84,6 +89,17 @@ export function syncVersion(rootDir) {
     // append rather than the string "undefined".
     return `${prefix}"${v}"${semi}${comment ?? ""}`;
   });
+
+  // 3. Atomic write phase — both payloads have been built and
+  // validated, so it is safe to commit them to disk. Writing both
+  // here (instead of writing server.json in step 1) means a regex
+  // miss in step 2 throws BEFORE any file mutates, so a failed
+  // `npm version` does not leave server.json one version ahead of
+  // src/server.ts. fs.writeFileSync is not transactional across
+  // multiple files, but ordering server.json before src/server.ts
+  // gives the next reader at least a self-consistent server.json
+  // even if the second write is interrupted.
+  writeFileSync(serverJsonPath, serverJsonOutput);
   writeFileSync(tsPath, updatedTs);
 
   return v;

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -58,7 +58,8 @@ export function syncVersion(rootDir) {
   // forward, src/server.ts still on the old literal — which then
   // smuggles a mismatched-metadata release into npm).
   const serverJsonPath = join(rootDir, "server.json");
-  const server = JSON.parse(readFileSync(serverJsonPath, "utf8"));
+  const serverJsonOriginal = readFileSync(serverJsonPath, "utf8");
+  const server = JSON.parse(serverJsonOriginal);
   server.version = v;
   for (const p of server.packages ?? []) {
     if (p.identifier === pkg.name) p.version = v;
@@ -120,8 +121,24 @@ export function syncVersion(rootDir) {
     throw err;
   }
   // Both tmp files exist and are consistent — promote in place.
+  // The two renames are best-effort atomic individually, but the
+  // window between them is not. If the second rename throws, the
+  // first has already shipped the new server.json while src/server.ts
+  // still holds the old literal — exactly the half-applied state this
+  // step is meant to prevent. Restore the original bytes on the
+  // promoted file before re-throwing so the caller sees a clean repo.
   renameSync(serverJsonTmp, serverJsonPath);
-  renameSync(tsTmp, tsPath);
+  try {
+    renameSync(tsTmp, tsPath);
+  } catch (err) {
+    try {
+      writeFileSync(serverJsonPath, serverJsonOriginal);
+    } catch {}
+    try {
+      unlinkSync(tsTmp);
+    } catch {}
+    throw err;
+  }
 
   return v;
 }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -65,17 +65,25 @@ export function syncVersion(rootDir) {
   const ts = readFileSync(tsPath, "utf8");
   // Anchor to a real declaration line — start-of-line + optional
   // indentation + the exact `export const VERSION = "..."` token
-  // sequence + an optional trailing semicolon. The previous
+  // sequence + an optional trailing semicolon + an optional trailing
+  // line comment (e.g. ` // x-release-please-version`). The previous
   // unanchored shape `(export const VERSION = )"[^"]*"` would
   // happily rewrite a comment like
   // `// Old: export const VERSION = "0.0.0"` or a string literal
   // containing the same byte sequence, silently corrupting the
-  // file. The `m` flag makes `^` match every line start.
-  const re = /^(\s*export const VERSION = )"[^"]*"(;?)$/m;
+  // file. The `m` flag makes `^` match every line start. The
+  // trailing-comment capture group preserves the release-please
+  // marker (and any other annotation) verbatim across the rewrite.
+  const re = /^(\s*export const VERSION = )"[^"]*"(;?)(\s*\/\/.*)?$/m;
   if (!re.test(ts)) {
     throw new Error("sync-version: did not find the VERSION constant in src/server.ts");
   }
-  const updatedTs = ts.replace(re, `$1"${v}"$2`);
+  const updatedTs = ts.replace(re, (_match, prefix, semi, comment) => {
+    // `comment` is `undefined` when the source line has no trailing
+    // comment; coerce to empty string so the rewrite is a no-op
+    // append rather than the string "undefined".
+    return `${prefix}"${v}"${semi}${comment ?? ""}`;
+  });
   writeFileSync(tsPath, updatedTs);
 
   return v;

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -10,7 +10,7 @@
 // bottom calls `syncVersion(process.cwd-derived root)` when the file is
 // executed directly via `node scripts/sync-version.mjs`.
 
-import { readFileSync, writeFileSync } from "node:fs";
+import { readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 
@@ -97,16 +97,31 @@ export function syncVersion(rootDir) {
   });
 
   // 3. Atomic write phase — both payloads have been built and
-  // validated, so it is safe to commit them to disk. Writing both
-  // here (instead of writing server.json in step 1) means a regex
-  // miss in step 2 throws BEFORE any file mutates, so a failed
-  // `npm version` does not leave server.json one version ahead of
-  // src/server.ts. fs.writeFileSync is not transactional across
-  // multiple files, but ordering server.json before src/server.ts
-  // gives the next reader at least a self-consistent server.json
-  // even if the second write is interrupted.
-  writeFileSync(serverJsonPath, serverJsonOutput);
-  writeFileSync(tsPath, updatedTs);
+  // validated, so it is safe to commit them to disk. Stage both
+  // outputs to temp files first; only after both temp writes
+  // succeed do we rename them into place. POSIX renameSync on the
+  // same filesystem is atomic, so a permission/disk error during
+  // the second writeFileSync no longer leaves the repo with a
+  // bumped server.json and a stale src/server.ts.
+  const serverJsonTmp = `${serverJsonPath}.tmp`;
+  const tsTmp = `${tsPath}.tmp`;
+  try {
+    writeFileSync(serverJsonTmp, serverJsonOutput);
+    writeFileSync(tsTmp, updatedTs);
+  } catch (err) {
+    // Either temp write failed; clean up any partial tmp and
+    // re-throw. The real files have NOT been touched yet.
+    try {
+      unlinkSync(serverJsonTmp);
+    } catch {}
+    try {
+      unlinkSync(tsTmp);
+    } catch {}
+    throw err;
+  }
+  // Both tmp files exist and are consistent — promote in place.
+  renameSync(serverJsonTmp, serverJsonPath);
+  renameSync(tsTmp, tsPath);
 
   return v;
 }

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -79,15 +79,21 @@ export function syncVersion(rootDir) {
   // file. The `m` flag makes `^` match every line start. The
   // trailing-comment capture group preserves the release-please
   // marker (and any other annotation) verbatim across the rewrite.
-  const re = /^(\s*export const VERSION = )"[^"]*"(;?)(\s*\/\/.*)?$/m;
+  // Tolerate trailing whitespace before EOL — a stray space after `;`
+  // (or after the release-please marker) is otherwise treated as a
+  // non-match and the script throws "did not find the VERSION
+  // constant". The trailing-whitespace capture is preserved verbatim
+  // so reformatters that intentionally pad the line stay byte-stable.
+  const re = /^(\s*export const VERSION = )"[^"]*"(;?)(\s*\/\/.*)?([ \t]*)$/m;
   if (!re.test(ts)) {
     throw new Error("sync-version: did not find the VERSION constant in src/server.ts");
   }
-  const updatedTs = ts.replace(re, (_match, prefix, semi, comment) => {
-    // `comment` is `undefined` when the source line has no trailing
-    // comment; coerce to empty string so the rewrite is a no-op
-    // append rather than the string "undefined".
-    return `${prefix}"${v}"${semi}${comment ?? ""}`;
+  const updatedTs = ts.replace(re, (_match, prefix, semi, comment, trailingWs) => {
+    // `comment` and `trailingWs` are `undefined` when the source line
+    // has no trailing comment / no trailing whitespace; coerce to
+    // empty string so the rewrite is a no-op append rather than the
+    // string "undefined".
+    return `${prefix}"${v}"${semi}${comment ?? ""}${trailingWs ?? ""}`;
   });
 
   // 3. Atomic write phase — both payloads have been built and

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -106,6 +106,12 @@ export function syncVersion(rootDir) {
   // bumped server.json and a stale src/server.ts.
   const serverJsonTmp = `${serverJsonPath}.tmp`;
   const tsTmp = `${tsPath}.tmp`;
+  /* v8 ignore start -- defensive temp-write failure path: both
+     writeFileSync calls hit a tmpdir that was just successfully
+     mkdtemp'd, so EACCES/ENOSPC during this window would require a
+     concurrent permission flip or out-of-band disk pressure — not
+     reproducible from the test runner. The cleanup is "best effort"
+     anyway; the next syncVersion run would overwrite the tmp regardless. */
   try {
     writeFileSync(serverJsonTmp, serverJsonOutput);
     writeFileSync(tsTmp, updatedTs);
@@ -120,6 +126,7 @@ export function syncVersion(rootDir) {
     } catch {}
     throw err;
   }
+  /* v8 ignore stop */
   // Both tmp files exist and are consistent — promote in place.
   // The two renames are best-effort atomic individually, but the
   // window between them is not. If the second rename throws, the
@@ -133,10 +140,18 @@ export function syncVersion(rootDir) {
   } catch (err) {
     try {
       writeFileSync(serverJsonPath, serverJsonOriginal);
-    } catch {}
+    } catch {
+      /* v8 ignore next -- defensive: failing to roll back is not
+         worse than not trying; swallow and re-throw the original
+         renameSync error so the operator sees the real cause. */
+    }
     try {
       unlinkSync(tsTmp);
-    } catch {}
+    } catch {
+      /* v8 ignore next -- tsTmp may have been moved by the failing
+         renameSync depending on which step inside it tripped; ENOENT
+         here is benign. */
+    }
     throw err;
   }
 

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -118,6 +118,27 @@ describe("syncVersion", () => {
     );
   });
 
+  it("does not partially write when src/server.ts validation fails (atomic on error)", () => {
+    // Pin the atomic-write contract: when `syncVersion` throws on a
+    // regex miss in step 2, NEITHER file must have been mutated. The
+    // previous shape wrote server.json in step 1 before validating
+    // src/server.ts in step 2, so a failed `npm version` would leave
+    // server.json bumped while src/server.ts kept the old literal —
+    // a half-applied bump that would smuggle mismatched metadata
+    // into the next release if the operator missed the throw.
+    writeFixture({
+      pkgVersion: "9.9.9",
+      tsContent: 'export const NOT_VERSION = "0.0.0";\n',
+    });
+    const serverJsonBefore = readFileSync(join(scratch, "server.json"), "utf8");
+    expect(() => syncVersion(scratch)).toThrow(/did not find the VERSION constant/);
+    const serverJsonAfter = readFileSync(join(scratch, "server.json"), "utf8");
+    // Byte-exact equality — even a re-serialisation with the same
+    // content (rewriting the bumped object) would defeat the
+    // atomicity contract because a later step could still throw.
+    expect(serverJsonAfter).toBe(serverJsonBefore);
+  });
+
   it("returns the version string for the caller (CLI uses it in the success log)", () => {
     writeFixture({ pkgVersion: "0.42.0" });
     const v = syncVersion(scratch);

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -153,6 +153,29 @@ describe("syncVersion", () => {
     expect(() => syncVersion(scratch)).toThrow(/package\.json#name/);
   });
 
+  it("preserves a trailing line comment on the VERSION declaration (release-please marker)", () => {
+    // Pin the trailing-comment branch — release-please's
+    // `extra-files: generic` matcher looks for the
+    // `// x-release-please-version` annotation on the same line as
+    // the version literal. Without this support, sync-version would
+    // strip the annotation on every bump, breaking release-please's
+    // version-detection on the next release. Cover both with-comment
+    // and without-comment forms in the same fixture.
+    writeFixture({
+      pkgVersion: "0.31.0",
+      tsContent:
+        [
+          'export const VERSION = "0.0.0"; // x-release-please-version',
+          'export const OTHER = "kept";',
+        ].join("\n") + "\n",
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    expect(ts).toContain('export const VERSION = "0.31.0"; // x-release-please-version');
+    // The companion declaration on the next line must be untouched.
+    expect(ts).toContain('export const OTHER = "kept";');
+  });
+
   it("does not rewrite VERSION-like patterns inside comments or string literals", () => {
     // Pin the anchored regex (`^(\\s*export const VERSION = )"..."(;?)$/m`)
     // — without the `^...$/m` anchors, the previous unanchored

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -197,6 +197,44 @@ describe("syncVersion", () => {
     expect(ts).toContain('export const OTHER = "kept";');
   });
 
+  it("tolerates trailing whitespace on the VERSION declaration line", () => {
+    // Pin the trailing-whitespace branch — some editors / autosave
+    // tooling pad lines with a stray space or tab before EOL. A
+    // strict `$` anchor without a `[ \t]*` capture would treat that
+    // padded line as a non-match and the script would throw "did not
+    // find the VERSION constant". Cover both `;<spaces>` and
+    // `;<comment><spaces>` forms.
+    writeFixture({
+      pkgVersion: "0.31.0",
+      tsContent:
+        [
+          'export const VERSION = "0.0.0";   ', // padded with spaces
+          'export const KEPT = "kept";',
+        ].join("\n") + "\n",
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    // Trailing whitespace is preserved verbatim so reformatters that
+    // intentionally pad the line stay byte-stable across the rewrite.
+    expect(ts).toContain('export const VERSION = "0.31.0";   ');
+    expect(ts).toContain('export const KEPT = "kept";');
+  });
+
+  it("tolerates trailing whitespace after the release-please marker", () => {
+    writeFixture({
+      pkgVersion: "0.31.0",
+      tsContent:
+        [
+          'export const VERSION = "0.0.0"; // x-release-please-version   ',
+        ].join("\n") + "\n",
+    });
+    syncVersion(scratch);
+    const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    expect(ts).toContain(
+      'export const VERSION = "0.31.0"; // x-release-please-version   ',
+    );
+  });
+
   it("does not rewrite VERSION-like patterns inside comments or string literals", () => {
     // Pin the anchored regex (`^(\\s*export const VERSION = )"..."(;?)$/m`)
     // — without the `^...$/m` anchors, the previous unanchored

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -2,17 +2,45 @@
 // against a tempdir-rooted fixture (package.json + server.json +
 // src/server.ts) so the real repo files are never touched.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { syncVersion } from "./sync-version.mjs";
+
+// Mock `node:fs#renameSync` so the rollback test can simulate a
+// failure on the second promotion rename. The hoisted mock is a pass-
+// through by default (`failOn === -1`); the rollback test flips
+// `renameState.failOn = 2` to make the second observed renameSync
+// throw, then resets it in `afterEach`. Every other consumer of
+// `node:fs` keeps the real implementation.
+const renameState = { count: 0, failOn: -1 };
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...actual,
+    default: actual,
+    renameSync: (from, to) => {
+      renameState.count += 1;
+      if (renameState.count === renameState.failOn) {
+        const err = new Error("simulated rename failure on src/server.ts");
+        err.code = "EACCES";
+        throw err;
+      }
+      return actual.renameSync(from, to);
+    },
+  };
+});
 
 let scratch;
 
 beforeEach(() => {
   scratch = mkdtempSync(join(tmpdir(), "sync-version-test-"));
   mkdirSync(join(scratch, "src"), { recursive: true });
+  // Reset the rename-mock state on every test so a previous test
+  // leaving `failOn` set cannot leak into the next one.
+  renameState.count = 0;
+  renameState.failOn = -1;
 });
 
 afterEach(() => {
@@ -131,12 +159,44 @@ describe("syncVersion", () => {
       tsContent: 'export const NOT_VERSION = "0.0.0";\n',
     });
     const serverJsonBefore = readFileSync(join(scratch, "server.json"), "utf8");
+    const tsBefore = readFileSync(join(scratch, "src", "server.ts"), "utf8");
     expect(() => syncVersion(scratch)).toThrow(/did not find the VERSION constant/);
     const serverJsonAfter = readFileSync(join(scratch, "server.json"), "utf8");
+    const tsAfter = readFileSync(join(scratch, "src", "server.ts"), "utf8");
     // Byte-exact equality — even a re-serialisation with the same
     // content (rewriting the bumped object) would defeat the
     // atomicity contract because a later step could still throw.
+    // Both files are checked so the contract covers the full "neither
+    // file mutates on failure" invariant, not just server.json.
     expect(serverJsonAfter).toBe(serverJsonBefore);
+    expect(tsAfter).toBe(tsBefore);
+  });
+
+  it("restores server.json to original bytes when the src/server.ts rename throws", () => {
+    // Pin the rollback contract on the second rename. The atomic-write
+    // phase stages both payloads to .tmp files and renames them in
+    // sequence; the first rename ships server.json forward, the
+    // second ships src/server.ts. If the second rename throws (EACCES,
+    // ENOSPC, EROFS, a cross-device move because the operator
+    // symlinked src/ elsewhere, …), server.json is left bumped while
+    // src/server.ts still holds the old literal — exactly the
+    // half-applied state this PR is meant to prevent.
+    // The hoisted vi.mock above intercepts renameSync; flip
+    // `renameState.failOn = 2` so the second observed call throws,
+    // then assert both files were rolled back to their original bytes.
+    writeFixture({ pkgVersion: "9.9.9" });
+    const serverJsonBefore = readFileSync(join(scratch, "server.json"), "utf8");
+    const tsBefore = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    renameState.failOn = 2;
+    expect(() => syncVersion(scratch)).toThrow(/simulated rename failure/);
+    const serverJsonAfter = readFileSync(join(scratch, "server.json"), "utf8");
+    const tsAfter = readFileSync(join(scratch, "src", "server.ts"), "utf8");
+    // The rollback writes the original bytes back to serverJsonPath
+    // after rename #1 has shipped the bumped tmp forward. Both files
+    // must end byte-identical to their pre-syncVersion state.
+    expect(renameState.count).toBe(2);
+    expect(serverJsonAfter).toBe(serverJsonBefore);
+    expect(tsAfter).toBe(tsBefore);
   });
 
   it("returns the version string for the caller (CLI uses it in the success log)", () => {
@@ -174,25 +234,32 @@ describe("syncVersion", () => {
     expect(() => syncVersion(scratch)).toThrow(/package\.json#name/);
   });
 
-  it("preserves a trailing line comment on the VERSION declaration (release-please marker)", () => {
+  it.each([
+    [
+      "with semicolon",
+      'export const VERSION = "0.0.0"; // x-release-please-version',
+      'export const VERSION = "0.31.0"; // x-release-please-version',
+    ],
+    [
+      "without semicolon",
+      'export const VERSION = "0.0.0" // x-release-please-version',
+      'export const VERSION = "0.31.0" // x-release-please-version',
+    ],
+  ])("preserves the release-please marker (%s)", (_label, before, after) => {
     // Pin the trailing-comment branch — release-please's
     // `extra-files: generic` matcher looks for the
     // `// x-release-please-version` annotation on the same line as
     // the version literal. Without this support, sync-version would
     // strip the annotation on every bump, breaking release-please's
-    // version-detection on the next release. Cover both with-comment
-    // and without-comment forms in the same fixture.
+    // version-detection on the next release. The optional-`;` capture
+    // in the regex is exercised by the no-semicolon row.
     writeFixture({
       pkgVersion: "0.31.0",
-      tsContent:
-        [
-          'export const VERSION = "0.0.0"; // x-release-please-version',
-          'export const OTHER = "kept";',
-        ].join("\n") + "\n",
+      tsContent: [before, 'export const OTHER = "kept";'].join("\n") + "\n",
     });
     syncVersion(scratch);
     const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
-    expect(ts).toContain('export const VERSION = "0.31.0"; // x-release-please-version');
+    expect(ts).toContain(after);
     // The companion declaration on the next line must be untouched.
     expect(ts).toContain('export const OTHER = "kept";');
   });

--- a/scripts/sync-version.test.mjs
+++ b/scripts/sync-version.test.mjs
@@ -224,15 +224,11 @@ describe("syncVersion", () => {
     writeFixture({
       pkgVersion: "0.31.0",
       tsContent:
-        [
-          'export const VERSION = "0.0.0"; // x-release-please-version   ',
-        ].join("\n") + "\n",
+        ['export const VERSION = "0.0.0"; // x-release-please-version   '].join("\n") + "\n",
     });
     syncVersion(scratch);
     const ts = readFileSync(join(scratch, "src", "server.ts"), "utf8");
-    expect(ts).toContain(
-      'export const VERSION = "0.31.0"; // x-release-please-version   ',
-    );
+    expect(ts).toContain('export const VERSION = "0.31.0"; // x-release-please-version   ');
   });
 
   it("does not rewrite VERSION-like patterns inside comments or string literals", () => {


### PR DESCRIPTION
## Summary
- The sync-version CLI throws `did not find the VERSION constant` against the live `src/server.ts` because the anchored regex required the line to end at the optional semicolon, but the declaration now carries a `// x-release-please-version` trailing comment (added in #112).
- Extend the regex with an optional trailing-comment capture group and preserve the captured comment verbatim on rewrite, so release-please's `extra-files: generic` matcher keeps its anchor on every bump.

## Test plan
- [x] Existing 18 tests still pass
- [x] New test pins the trailing-marker preservation
- [x] `node scripts/sync-version.mjs` now succeeds locally and updates `src/server.ts` correctly