### PR TITLE
ci(leak-detect): re-pin reusable workflow to fix yq checksum SHA

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -27,7 +27,7 @@ jobs:
     # fail as a required check. Leak scanning of fork PRs is enforced
     # post-merge by the maintainer-side push trigger on main.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@a2618fb7c675a9f6bbbd68f0f957dd5ffa1b5c10
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@e302f5295abbccbfbb36769721cdde1529013ba3
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps pinned SHA to fix yq install (multi-column checksums). Same fix cascaded across MCPs after PR #27 on klodr/.github merged.