### PR TITLE
ci: fix four workflow errors (pinact, gitleaks, auto-merge, coderabbit)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,7 +45,7 @@ reviews:
     docstrings:
       # The codebase deliberately keeps comments to non-obvious WHY only.
       # MCP tool descriptions live in Zod .describe() calls, not JSDoc.
-      mode: off
+      mode: "off"
     title:
       # Enforce conventional-commit format + 72-char cap (matches the
       # auto_title_instructions above — this is the gate that actually

--- a/.github/workflows/actions-pinned.yml
+++ b/.github/workflows/actions-pinned.yml
@@ -24,7 +24,9 @@ jobs:
 
       - uses: suzuki-shunsuke/pinact-action@cf51507d80d4d6522a07348e3d58790290eaf0b6 # v2.0.0
         with:
-          version: v3.9.2
+          # `version` was removed in pinact-action v2: the pinact binary
+          # is now bundled with the action tag, so the action SHA above
+          # is the only thing pinning the pinact version.
           skip_push: "true"
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -17,11 +17,19 @@ on:
   pull_request:
     types: [opened, reopened, synchronize]
 
-permissions:
-  contents: read
-
 jobs:
   call:
+    # The reusable workflow needs to arm `gh pr merge --auto` (writes the
+    # PR's auto-merge field via the PullRequest GraphQL mutation) and
+    # delete the branch on merge — hence `contents: write` (branch delete)
+    # and `pull-requests: write` (auto-merge field). The reusable's
+    # `permissions:` ceiling cannot exceed what the caller grants here,
+    # so the caller grant must match exactly. Job-level (not workflow-
+    # level) so any future job added to this file cannot accidentally
+    # inherit write scope.
+    permissions:
+      contents: write
+      pull-requests: write
     # Defense-in-depth: gate secrets at the caller before they're passed to
     # the reusable workflow. The reusable also has its own bot-login filter,
     # but matching here means the secrets are only forwarded for the one

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -41,3 +41,10 @@ jobs:
         uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7 # v2.3.9
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # gitleaks-action v2.3.9 declares `runs.using: node20`, which
+          # GitHub will force to node24 by default starting 2026-06-02
+          # and remove node20 entirely 2026-09-16. Opt into node24 now
+          # to silence the deprecation warning and validate compatibility
+          # before the forced flip. Upstream has not cut a node24 release
+          # since v2.3.9 (2025-04-17); revisit when a successor lands.
+          FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"


### PR DESCRIPTION
Mirrors klodr/eslint-plugin-security-mcp#35.

Four unrelated workflow-config failures; one PR since each is one-line fix.

- `actions-pinned.yml`: pinact-action v2 removed the `version` input — drop it.
- `auto-merge-release-please.yml`: move `permissions:` to job-level with `contents: write` + `pull-requests: write`.
- `gitleaks.yml`: `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true` to silence Node 20 deprecation.
- `.coderabbit.yaml`: quote `mode: "off"` for yamllint truthy.

## Test plan

- [x] yamllint pass (pre-commit hook)
- [ ] CI green
- [ ] CodeRabbit review pass