### PR TITLE
chore(lint): reactivate 6 markdownlint rules previously disabled

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -1,20 +1,18 @@
 {
   // markdownlint-cli2 — relaxed config for klodr/* MCP+plugin docs.
   // See https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md
+  // 5 rules disabled — all justified by content shape, not by author
+  // convenience. Everything else (MD012, MD028, MD029, MD036, MD049,
+  // MD050) is on; commit hooks + CI now reject the corresponding
+  // findings instead of letting them rot.
   "default": true,
-  "MD012": false, // multiple consecutive blank lines: cosmetic
   "MD013": false, // line-length: README has long URLs / badges
   "MD024": { "siblings_only": true }, // duplicate headings OK in CHANGELOG sections
-  "MD028": false, // blank line inside blockquote: useful for separating cite paragraphs
-  "MD029": false, // ordered list prefix: accept any style (1.1.1, 1.2.3, mixed)
   "MD033": false, // inline HTML allowed (badges, details/summary)
   "MD034": false, // bare URLs allowed (some places intentional)
-  "MD036": false, // emphasis as heading: false positives on snapshot dates etc.
   "MD041": false, // first line H1: badges/comments may precede
   "MD046": { "style": "fenced" }, // code block style: fenced
-  "MD049": false, // emphasis style: asterisk OR underscore
-  "MD050": false, // strong style: asterisk OR underscore
-  "MD060": false, // table column alignment: compact OR aligned, both OK
+  "MD060": false, // table column alignment: too many existing tables in compact-but-unaligned style
   "globs": ["**/*.md"],
   "ignores": ["node_modules/**", "coverage/**", "CHANGELOG.md"],
 }

--- a/docs/COMPETITORS.md
+++ b/docs/COMPETITORS.md
@@ -1,6 +1,6 @@
 # Competitors & ecosystem snapshot
 
-_Snapshot: 2026-04-27_
+Snapshot taken on **2026-04-27**.
 
 ## Why this page exists
 


### PR DESCRIPTION
## Summary

Reactivates **MD012/MD028/MD029/MD036/MD049/MD050** in \`.markdownlint.jsonc\`. Empirical audit found a single finding:

- \`docs/COMPETITORS.md:3\` MD036 — \`_Snapshot: 2026-04-27_\` (italic-as-heading) reworded into a normal sentence.

The four kept disables (MD013/MD033/MD034/MD041) are structurally justified.

**MD060** stays off — 82 findings on this repo's existing tables alone.

## Test plan

- [x] \`markdownlint-cli2\` clean on \`**/*.md\` (0 errors)
- [ ] CI green
- [ ] CodeRabbit review pass