### PR TITLE
chore(ci): reduce release-please trigger to 1 workflow_run

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -35,8 +35,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  group: release-please-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: true
 
 jobs:
   release-please:


### PR DESCRIPTION
Trigger sur CodeQL Advanced uniquement (le plus lent) + concurrency SHA-based cancel-in-progress. Gate cross-workflow inchangé.