### PR TITLE
ci(leak-detect): bump reusable SHA for app-id fix

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -27,7 +27,7 @@ jobs:
     # fail as a required check. Leak scanning of fork PRs is enforced
     # post-merge by the maintainer-side push trigger on main.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@e302f5295abbccbfbb36769721cdde1529013ba3
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@8c521f77c06a1498152965e9389a8f447e3e29f6
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps the pinned SHA of `klodr/.github/.github/workflows/reusable-leak-detect.yml` to `8c521f7` to pick up the [app-id input fix](https://github.com/klodr/.github/pull/34) (Client ID via `app-id` instead of `client-id` — v3.1.1 of `actions/create-github-app-token` mishandled iss=string).