### PR TITLE
ci: bump reusable SHAs to current klodr/.github main (orphan fix)

### DIFF
--- a/.github/workflows/auto-merge-release-please.yml
+++ b/.github/workflows/auto-merge-release-please.yml
@@ -44,7 +44,7 @@ jobs:
     # but matching here means the secrets are only forwarded for the one
     # event that needs them, and human/dependabot PRs short-circuit early.
     if: ${{ github.event.pull_request.user.login == 'klodr-release-please[bot]' }}
-    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@5a3a5093bc93bc2a682b5a0cb438149af2516f4c
+    uses: klodr/.github/.github/workflows/reusable-auto-merge-release-please.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     secrets:
       RELEASE_PLEASE_CLIENT_ID: ${{ secrets.RELEASE_PLEASE_CLIENT_ID }}
       RELEASE_PLEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@31517bee59b358945f7af0fdb3960085e0f3ec78
+    uses: klodr/.github/.github/workflows/reusable-node-ci.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -27,7 +27,7 @@ jobs:
     # fail as a required check. Leak scanning of fork PRs is enforced
     # post-merge by the maintainer-side push trigger on main.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@e302f5295abbccbfbb36769721cdde1529013ba3
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     secrets:
       leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}

--- a/.github/workflows/lint-yaml-md.yml
+++ b/.github/workflows/lint-yaml-md.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   lint:
-    uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@26b7f93b5a39c544f4414ada76cd2c79d9732bbd
+    uses: klodr/.github/.github/workflows/reusable-lint-yaml-md.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
     with:
       # markdownlint-cli2-action splits globs by newline (NOT space).
       # Pass each pattern on its own line; `#prefix` excludes.


### PR DESCRIPTION
The previously pinned SHAs (`26b7f93b`, `e302f529`, `5a3a5093`, `31517bee`) became orphans after their PRs were squash-merged on klodr/.github — they exist as commits but are no longer reachable from any branch. GitHub Actions now refuses to load reusable workflows from unreachable SHAs, causing startup_failure with `referenced_workflows: []` and 0 spawned jobs on every PR.

Bumps all 4 caller workflows (ci.yml, lint-yaml-md.yml, auto-merge-release-please.yml, leak-detect.yml) to current klodr/.github main HEAD `63627d28`.