### PR TITLE
ci(leak-detect): bump to inline-JWT reusable + drop client-id

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -27,7 +27,6 @@ jobs:
     # fail as a required check. Leak scanning of fork PRs is enforced
     # post-merge by the maintainer-side push trigger on main.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@63627d28c0e716176f24f06f4d3cad6c1abf3648
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@7987f59050ff9ee614d21b603e4ba87ace27f7d9
     secrets:
-      leak-detect-client-id: ${{ secrets.LEAK_DETECT_CLIENT_ID }}
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Bumps reusable workflow SHA to klodr/.github main `7987f590` (inline JWT signing fix) and drops the now-unused `leak-detect-client-id` secret from the call (App ID is hardcoded in the reusable since GH Actions masks secret values at runtime, defeating int() parsing — and App IDs are public anyway).