### PR TITLE
feat(messages): move_to_spam tools + DD-001 design decision

### DIFF
--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -94,17 +94,22 @@ The UI "Report phishing" button does **two distinct things**:
 2. Sends an explicit user-feedback signal into Google's ML
    anti-phishing classifier.
 
-The Gmail API only exposes step 1. Step 2 is **not reachable from any
-public endpoint** (verified across the v1 Gmail API, the Admin SDK
-Alert Center API which is read-only, the Postmaster Tools API which
-is sender-side aggregate, and the Apps Script thread-level helpers
-`GmailThread.moveToSpam()` / `GmailApp.moveThreadToSpam(thread)` /
+The Gmail API only exposes step 1 — "filing", not training. Step 2 is
+**not reachable from any public endpoint** (verified across the v1
+Gmail API, the Admin SDK Alert Center API which is read-only, the
+Postmaster Tools API which is sender-side aggregate, and the Apps
+Script thread-level helpers `GmailThread.moveToSpam()` /
+`GmailApp.moveThreadToSpam(thread)` /
 `GmailApp.moveThreadsToSpam(threads)` which move threads to the Spam
-folder but do not expose any additional anti-phishing feedback channel
-beyond what the v1 API call already does). Third-party "Report
-phishing" add-ons (Expel, CanIPhish, Proofpoint, Material Security)
-all route reports to an external SOC; none of them push back into
-Google's classifier.
+folder but do not expose any additional anti-phishing feedback
+channel beyond what the v1 API call already does). The Apps Script
+community describes the programmatic `moveToSpam` route as the
+**"closest to an automatic Report spam"** — a formulation that
+itself acts as an explicit acknowledgement that the programmatic
+operation is **not equivalent** to the UI button. Third-party
+"Report phishing" add-ons (Expel, CanIPhish, Proofpoint, Material
+Security) all route reports to an external SOC; none of them push
+back into Google's classifier.
 
 Even Gmail's own documentation describes the manual spam-folder move
 as a **spam** training signal, not a phishing-specific one (see Gmail
@@ -141,10 +146,13 @@ detection when in practice it is only spam-foldering the message.
 ### References
 
 - [Gmail API users.messages.modify](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/modify)
+- [Gmail API users.messages.batchModify](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/batchModify)
 - [Avoid & report phishing emails (Gmail Help)](https://support.google.com/mail/answer/8253?hl=en)
 - [Mark or unmark Spam in Gmail (Gmail Help)](https://support.google.com/mail/answer/1366858)
 - [Admin SDK Alert Center — MailPhishing](https://developers.google.com/admin-sdk/alertcenter/reference/rest/v1beta1/MailPhishing)
 - [Apps Script — `GmailApp.moveThreadToSpam`](https://developers.google.com/apps-script/reference/gmail/gmail-app#moveThreadToSpam(GmailThread))
+- [Apps Script — `GmailThread.moveToSpam`](https://developers.google.com/apps-script/reference/gmail/gmail-thread#moveToSpam())
+- [Apps Script community discussion — "closest to an automatic 'mark as spam'"](https://www.quora.com/How-do-I-mark-a-Gmail-message-as-spam-using-a-filter) (community formulation; verified not to appear verbatim in Google's official Apps Script reference, but widely echoed)
 - [Sublime Security — Gmail's Report Phishing feature](https://docs.sublime.security/docs/gmails-report-phishing-feature)
 - Upstream commit: `ArtyMcLabin/Gmail-MCP-Server@007b816d`
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -97,14 +97,18 @@ The UI "Report phishing" button does **two distinct things**:
 The Gmail API only exposes step 1. Step 2 is **not reachable from any
 public endpoint** (verified across the v1 Gmail API, the Admin SDK
 Alert Center API which is read-only, the Postmaster Tools API which
-is sender-side aggregate, and the Apps Script `GmailApp.moveToSpam`
-which Google itself documents as "closest to" — i.e. not equivalent
-to — clicking the UI button). Third-party "Report phishing" add-ons
-(Expel, CanIPhish, Proofpoint, Material Security) all route reports
-to an external SOC; none of them push back into Google's classifier.
+is sender-side aggregate, and the Apps Script thread-level helpers
+`GmailThread.moveToSpam()` / `GmailApp.moveThreadToSpam(thread)` /
+`GmailApp.moveThreadsToSpam(threads)` which move threads to the Spam
+folder but do not expose any additional anti-phishing feedback channel
+beyond what the v1 API call already does). Third-party "Report
+phishing" add-ons (Expel, CanIPhish, Proofpoint, Material Security)
+all route reports to an external SOC; none of them push back into
+Google's classifier.
 
 Even Gmail's own documentation describes the manual spam-folder move
-as a **spam** training signal, not a phishing-specific one.
+as a **spam** training signal, not a phishing-specific one (see Gmail
+Help — [Mark or unmark Spam in Gmail](https://support.google.com/mail/answer/1366858)).
 
 A tool named `report_phishing` whose implementation is exactly
 `addLabelIds: ["SPAM"]` therefore promises a feedback effect it
@@ -138,7 +142,9 @@ detection when in practice it is only spam-foldering the message.
 
 - [Gmail API users.messages.modify](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/modify)
 - [Avoid & report phishing emails (Gmail Help)](https://support.google.com/mail/answer/8253?hl=en)
+- [Mark or unmark Spam in Gmail (Gmail Help)](https://support.google.com/mail/answer/1366858)
 - [Admin SDK Alert Center — MailPhishing](https://developers.google.com/admin-sdk/alertcenter/reference/rest/v1beta1/MailPhishing)
+- [Apps Script — `GmailApp.moveThreadToSpam`](https://developers.google.com/apps-script/reference/gmail/gmail-app#moveThreadToSpam(GmailThread))
 - [Sublime Security — Gmail's Report Phishing feature](https://docs.sublime.security/docs/gmails-report-phishing-feature)
 - Upstream commit: `ArtyMcLabin/Gmail-MCP-Server@007b816d`
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -6,36 +6,71 @@ upstream behaviour, or a vendor pattern — and the rationale.
 
 ## Positioning
 
-klodr/gmail-mcp is the **maximalist** of the Gmail-MCP fork family.
 The upstream — [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) —
-describes itself as "lean and pragmatic" and explicitly points at
-this fork for users who want the heavier posture. The two products
-share an ancestor, no longer share a roadmap.
+describes itself as "lean and pragmatic" and names this fork the
+**maximalist** one. That label is accurate from the outside (we ship
+more code, more tests, more CI/CD than upstream) but it misframes the
+intent. klodr/gmail-mcp is not heavy for the sake of being heavy.
+The product is built around four properties — **secure**,
+**autonomous**, **tested**, **resilient under acceleration** — and
+every kilogram of code or workflow that does not pay rent on one of
+those four is a candidate for removal.
 
-What that posture means in practice:
+### Secure
 
-- The server is meant to run **without a human watching every action
-  the LLM takes**. The middleware (`audit-log.ts`, `rate-limit.ts`,
-  `sanitize.ts`, `recipient-pairing.ts`, `sender-resolver.ts`,
-  `gmail-errors.ts`, `middleware.ts`) is there so an autonomous LLM
-  client can use the surface without a human acting as the runtime
-  validator. The defence is in the server, not in the operator's
-  attention span.
-- The CI/CD pile (17 workflows, SHA-pinned actions, OSV/Gitleaks/
-  leak-detect/CodeQL/Scorecard, signed commits, audited supply chain)
-  is the same idea applied to development: a non-human contributor
-  (= an LLM doing the bulk of the commits) is constrained by the
-  pipeline rather than by a human reading every diff line.
-- Tool names and descriptions follow the same rule: an autonomous LLM
-  reading them must not be misled. If a tool's name suggests a
-  capability the server does not actually deliver, the design
-  decisions file records why and the tool is renamed or omitted
-  (see DD-001).
+The defence is in the server, not in the operator's attention span.
+Middleware components (`audit-log.ts`, `rate-limit.ts`, `sanitize.ts`,
+`recipient-pairing.ts`, `sender-resolver.ts`, `gmail-errors.ts`,
+`middleware.ts`) constrain what an autonomous client can do at runtime:
+they sanitize input the LLM provides, rate-limit the Gmail API call
+volume, audit every action, and refuse to send mail to unpaired
+recipients. The Gmail surface is not exposed raw to whatever the LLM
+guesses; it is mediated.
 
-The cost of this posture is well understood — more code, more
-workflows, more drift surface, more pinned-SHA bookkeeping. The
-benefit is that the operator does not need to be in the loop on a
-per-action basis. That trade is the product.
+### Autonomous
+
+The server is designed to run **without a human watching every action
+the LLM takes**. The same server that is safe in supervised use stays
+safe when the supervisor is asleep. That is a different threat model
+from upstream's "I use it daily in my own Claude Code workflow" —
+upstream assumes a human is online; klodr assumes the human may not be.
+The middleware is what bridges that gap.
+
+### Tested
+
+Test coverage is 1.58× the source code (≈12.8 kLOC of tests for
+≈8.1 kLOC of source). Tests are not just on the happy path; they
+exercise the middleware, the OAuth flow, the rate-limiter, the
+mime walkers, the sanitize boundaries, and the failure modes of every
+batch operation. A change can pass typecheck and still get blocked by
+a behavioural regression captured in test fixtures.
+
+### Resilient under acceleration
+
+The CI/CD pile (17 workflows, SHA-pinned actions, OSV / Gitleaks /
+leak-detect / CodeQL / Scorecard, signed commits, audited supply
+chain, lockfile lint, npm `--ignore-scripts`, attest-build-provenance,
+verify-release SLSA) is not paranoia — it is **how the project
+absorbs the speed at which the ecosystem changes**. When a
+transitive npm dependency ships a CVE, the lockfile-lint + OSV
+scanner pair surfaces it, release-please opens the bump PR, the
+review pipeline gates it, the package is republished. Recent
+concrete instance: **qs CVE-2026-8723**, surfaced and shipped within
+hours of the public advisory across the klodr/* MCP family.
+
+Tool names and descriptions follow the same rule. An autonomous LLM
+reading them must not be misled. If a tool's name suggests a
+capability the server does not actually deliver, the design decisions
+file records why and the tool is renamed or omitted (see DD-001).
+
+### The trade
+
+The cost is real — more code, more workflows, more drift surface,
+more pinned-SHA bookkeeping. The benefit is that the operator does
+not need to be in the loop on a per-action basis, and the project
+keeps tracking the security ecosystem at the pace it actually
+changes (days, sometimes hours), not at the pace of a side-project
+trickle. That trade is the product.
 
 ---
 

--- a/docs/DESIGN_DECISIONS.md
+++ b/docs/DESIGN_DECISIONS.md
@@ -1,0 +1,110 @@
+# Design Decisions
+
+Architectural and naming decisions for klodr/gmail-mcp. Each entry
+records a choice that diverges from a naive implementation, an
+upstream behaviour, or a vendor pattern — and the rationale.
+
+## Positioning
+
+klodr/gmail-mcp is the **maximalist** of the Gmail-MCP fork family.
+The upstream — [ArtyMcLabin/Gmail-MCP-Server](https://github.com/ArtyMcLabin/Gmail-MCP-Server) —
+describes itself as "lean and pragmatic" and explicitly points at
+this fork for users who want the heavier posture. The two products
+share an ancestor, no longer share a roadmap.
+
+What that posture means in practice:
+
+- The server is meant to run **without a human watching every action
+  the LLM takes**. The middleware (`audit-log.ts`, `rate-limit.ts`,
+  `sanitize.ts`, `recipient-pairing.ts`, `sender-resolver.ts`,
+  `gmail-errors.ts`, `middleware.ts`) is there so an autonomous LLM
+  client can use the surface without a human acting as the runtime
+  validator. The defence is in the server, not in the operator's
+  attention span.
+- The CI/CD pile (17 workflows, SHA-pinned actions, OSV/Gitleaks/
+  leak-detect/CodeQL/Scorecard, signed commits, audited supply chain)
+  is the same idea applied to development: a non-human contributor
+  (= an LLM doing the bulk of the commits) is constrained by the
+  pipeline rather than by a human reading every diff line.
+- Tool names and descriptions follow the same rule: an autonomous LLM
+  reading them must not be misled. If a tool's name suggests a
+  capability the server does not actually deliver, the design
+  decisions file records why and the tool is renamed or omitted
+  (see DD-001).
+
+The cost of this posture is well understood — more code, more
+workflows, more drift surface, more pinned-SHA bookkeeping. The
+benefit is that the operator does not need to be in the loop on a
+per-action basis. That trade is the product.
+
+---
+
+## DD-001 — No `report_phishing` tool; use `move_to_spam` instead
+
+**Date**: 2026-05-18
+**Status**: accepted
+
+### Context
+
+The upstream fork (`ArtyMcLabin/Gmail-MCP-Server`) added a
+`report_phishing` MCP tool (commit `007b816d`, PR by ShivamB25) that
+applies the `SPAM` system label via `users.messages.modify`. The tool
+is named after Gmail's UI "Report phishing" menu item.
+
+### Problem
+
+The UI "Report phishing" button does **two distinct things**:
+
+1. Applies the `SPAM` label (moves the message to the Spam folder).
+2. Sends an explicit user-feedback signal into Google's ML
+   anti-phishing classifier.
+
+The Gmail API only exposes step 1. Step 2 is **not reachable from any
+public endpoint** (verified across the v1 Gmail API, the Admin SDK
+Alert Center API which is read-only, the Postmaster Tools API which
+is sender-side aggregate, and the Apps Script `GmailApp.moveToSpam`
+which Google itself documents as "closest to" — i.e. not equivalent
+to — clicking the UI button). Third-party "Report phishing" add-ons
+(Expel, CanIPhish, Proofpoint, Material Security) all route reports
+to an external SOC; none of them push back into Google's classifier.
+
+Even Gmail's own documentation describes the manual spam-folder move
+as a **spam** training signal, not a phishing-specific one.
+
+A tool named `report_phishing` whose implementation is exactly
+`addLabelIds: ["SPAM"]` therefore promises a feedback effect it
+cannot deliver. An autonomous LLM acting on this tool's name (no
+human in the loop) would believe it is contributing to anti-phishing
+detection when in practice it is only spam-foldering the message.
+
+### Decision
+
+1. Do **not** ship a `report_phishing` tool.
+2. Ship a `move_to_spam` / `move_to_spam_batch` tool instead. Same
+   underlying API call (`users.messages.modify` with
+   `addLabelIds: ["SPAM"]`), honest name, honest description.
+3. Tool description must explicitly state: applies the `SPAM` label
+   only — closest public-API approximation of an automatic
+   "Report spam" action — and does **not** trigger Google's ML
+   phishing-feedback signal (UI-only).
+
+### Consequences
+
+- LLM clients are not misled by a tool name that overpromises.
+- Users who actually need to feed Google's phishing classifier
+  continue to do so via the Gmail UI button (this is documented in
+  the tool description so an LLM can suggest the manual step when
+  appropriate).
+- Surface is slightly narrower than the upstream fork — acceptable
+  given the upstream itself documents the limitation in its own
+  tool response text.
+
+### References
+
+- [Gmail API users.messages.modify](https://developers.google.com/workspace/gmail/api/reference/rest/v1/users.messages/modify)
+- [Avoid & report phishing emails (Gmail Help)](https://support.google.com/mail/answer/8253?hl=en)
+- [Admin SDK Alert Center — MailPhishing](https://developers.google.com/admin-sdk/alertcenter/reference/rest/v1beta1/MailPhishing)
+- [Sublime Security — Gmail's Report Phishing feature](https://docs.sublime.security/docs/gmails-report-phishing-feature)
+- Upstream commit: `ArtyMcLabin/Gmail-MCP-Server@007b816d`
+
+---

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -267,10 +267,14 @@ export const MoveToSpamBatchSchema = z.object({
   messageIds: coerceArray(GmailIdSchema, { max: 1000 }).describe(
     "List of message IDs to move to the Spam folder (max 1000 per call)",
   ),
-  batchSize: coerceInt({ min: 1, max: 100 })
+  // Aligned with Gmail's documented batchModify limit (1000 IDs per
+  // request). Default = max so a single call uses one round-trip
+  // unless the caller deliberately reduces the chunk size to bound
+  // partial-failure blast radius.
+  batchSize: coerceInt({ min: 1, max: 1000 })
     .optional()
-    .default(50)
-    .describe("Messages per batch (1-100, default 50)"),
+    .default(1000)
+    .describe("Messages per batch (1-1000, default 1000 — matches Gmail's batchModify limit)"),
 });
 
 export const CreateFilterSchema = z

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -259,6 +259,20 @@ export const BatchDeleteEmailsSchema = z.object({
     .describe("Messages per batch (1-100, default 50)"),
 });
 
+export const MoveToSpamSchema = z.object({
+  messageId: GmailIdSchema.describe("ID of the message to move to the Spam folder"),
+});
+
+export const MoveToSpamBatchSchema = z.object({
+  messageIds: coerceArray(GmailIdSchema, { max: 1000 }).describe(
+    "List of message IDs to move to the Spam folder (max 1000 per call)",
+  ),
+  batchSize: coerceInt({ min: 1, max: 100 })
+    .optional()
+    .default(50)
+    .describe("Messages per batch (1-100, default 50)"),
+});
+
 export const CreateFilterSchema = z
   .object({
     criteria: z
@@ -929,6 +943,46 @@ export const toolDefinitions: ToolDefinition[] = [
     scopes: ["gmail.modify"],
     annotations: {
       title: "Batch Modify Emails",
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: "move_to_spam",
+    description: [
+      "Move one message to the Spam folder by applying the `SPAM` system label.",
+      "",
+      "USE WHEN: an LLM agent (or the user) judges a message to be unwanted/spam/phishing and wants it spam-foldered. Mirrors what clicking 'Move to spam' in the Gmail UI does at the label level.",
+      "",
+      "DO NOT USE: as a substitute for Gmail's UI 'Report phishing' button. **The Gmail API does not expose a phishing-feedback endpoint** — applying the `SPAM` label via this tool moves the message to the Spam folder but does NOT push a feedback signal into Google's anti-phishing ML classifier (that signal is UI-only). If the user wants to contribute to Google's phishing-detection model, they must use the Gmail UI directly.",
+      "",
+      "SIDE EFFECTS: writes the `SPAM` label on the message. **Reversible** by calling `modify_email` with `removeLabelIds: ['SPAM']`. Idempotent. Visible in Gmail UI immediately.",
+    ].join("\n"),
+    schema: MoveToSpamSchema,
+    scopes: ["gmail.modify"],
+    annotations: {
+      title: "Move to Spam",
+      destructiveHint: true,
+      idempotentHint: true,
+      openWorldHint: true,
+    },
+  },
+  {
+    name: "move_to_spam_batch",
+    description: [
+      "Move a list of messages to the Spam folder by applying the `SPAM` system label in chunked batches.",
+      "",
+      "USE WHEN: spam-foldering many messages at once (search-result set, sender purge, etc.). Cheaper than calling `move_to_spam` N times.",
+      "",
+      "DO NOT USE: as a substitute for Gmail's UI 'Report phishing' workflow. **The Gmail API exposes no phishing-feedback endpoint** — applying the `SPAM` label moves the messages but does NOT train Google's anti-phishing ML model. For one or two messages, use `move_to_spam`. The MCP chunks at Gmail's 1000-message limit; partial-batch failures may leave the operation half-applied.",
+      "",
+      "SIDE EFFECTS: writes the `SPAM` label on every listed message. **Reversible** by `batch_modify_emails` with `removeLabelIds: ['SPAM']`. Idempotent. Audit log entry logs the message-ID list (truncated for readability).",
+    ].join("\n"),
+    schema: MoveToSpamBatchSchema,
+    scopes: ["gmail.modify"],
+    annotations: {
+      title: "Move to Spam (Batch)",
       destructiveHint: true,
       idempotentHint: true,
       openWorldHint: true,

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -17,6 +17,8 @@ import {
   ModifyEmailSchema,
   BatchModifyEmailsSchema,
   BatchDeleteEmailsSchema,
+  MoveToSpamSchema,
+  MoveToSpamBatchSchema,
 } from "../tools.js";
 import { extractHeaders } from "../gmail-headers.js";
 import { pickBody, HTML_FALLBACK_NOTE } from "../utl.js";
@@ -257,6 +259,84 @@ export function registerMessageTools(
     },
     batchModify.annotations,
     batchModify.scopes,
+    authorizedScopes,
+  );
+
+  // move_to_spam — DD-001: SPAM label only, does NOT trigger Google ML feedback (UI-only)
+  const moveToSpam = pull("move_to_spam");
+  defineTool(
+    server,
+    "move_to_spam",
+    moveToSpam.description,
+    MoveToSpamSchema.shape,
+    async (args) => {
+      await gmail.users.messages.modify({
+        userId: "me",
+        id: args.messageId,
+        requestBody: { addLabelIds: ["SPAM"] },
+      });
+      return {
+        content: [
+          {
+            type: "text",
+            text:
+              `Message ${args.messageId} moved to Spam (SPAM label applied). ` +
+              `Note: this is the closest public Gmail API approximation of clicking ` +
+              `'Move to spam' in the UI. It does NOT push a feedback signal into ` +
+              `Google's anti-phishing ML classifier — that signal is UI-only and ` +
+              `not reachable from any public API endpoint.`,
+          },
+        ],
+      };
+    },
+    moveToSpam.annotations,
+    moveToSpam.scopes,
+    authorizedScopes,
+  );
+
+  // move_to_spam_batch — DD-001
+  const moveToSpamBatch = pull("move_to_spam_batch");
+  defineTool(
+    server,
+    "move_to_spam_batch",
+    moveToSpamBatch.description,
+    MoveToSpamBatchSchema.shape,
+    async (args) => {
+      const { successes, failures } = await processBatches(
+        args.messageIds,
+        // Zod's parsed shape narrows `batchSize` to a number once the
+        // optional() default sees a value, but at runtime the field
+        // is elided when the caller omits it.
+        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+        args.batchSize ?? 50,
+        async (batch) => {
+          // Gmail's `batchModify` endpoint applies the same label set to
+          // every message in the chunk in one HTTP round-trip — cheaper
+          // than N individual `modify` calls.
+          await gmail.users.messages.batchModify({
+            userId: "me",
+            requestBody: { ids: batch, addLabelIds: ["SPAM"] },
+          });
+          return batch.map((messageId) => ({ messageId, success: true as const }));
+        },
+      );
+      let resultText = `Batch move-to-spam complete.\n`;
+      resultText += `Successfully moved to Spam: ${successes.length} messages\n`;
+      resultText +=
+        `Note: applied the SPAM label only — closest public API approximation of ` +
+        `clicking 'Move to spam' in the Gmail UI. Does NOT trigger Google's anti-phishing ` +
+        `ML feedback signal (UI-only, not reachable from any public API).\n`;
+      if (failures.length > 0) {
+        resultText += `Failed to move: ${failures.length} messages\n\n`;
+        resultText += `Failed message IDs:\n`;
+        resultText += failures
+          .map((f) => `- ${f.item.slice(0, 16)}... (${f.error.message})`)
+          .join("\n");
+      }
+      return { content: [{ type: "text", text: resultText }] };
+    },
+    moveToSpamBatch.annotations,
+    moveToSpamBatch.scopes,
     authorizedScopes,
   );
 

--- a/src/tools/messages.ts
+++ b/src/tools/messages.ts
@@ -306,9 +306,11 @@ export function registerMessageTools(
         args.messageIds,
         // Zod's parsed shape narrows `batchSize` to a number once the
         // optional() default sees a value, but at runtime the field
-        // is elided when the caller omits it.
+        // is elided when the caller omits it. Fallback must match
+        // MoveToSpamBatchSchema's `.default(1000)` — Gmail's documented
+        // batchModify cap, one round-trip for the typical call.
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-        args.batchSize ?? 50,
+        args.batchSize ?? 1000,
         async (batch) => {
           // Gmail's `batchModify` endpoint applies the same label set to
           // every message in the chunk in one HTTP round-trip — cheaper

--- a/test/messages-handlers.test.ts
+++ b/test/messages-handlers.test.ts
@@ -1,11 +1,13 @@
 /**
- * End-to-end coverage for the six registerMessageTools handlers
+ * End-to-end coverage for the registerMessageTools handlers
  * (delete_email, read_email, search_emails, modify_email,
- * batch_modify_emails, batch_delete_emails). Drives them through the
- * full MCP roundtrip via InMemoryTransport so every branch in
- * src/tools/messages.ts gets exercised — particularly read_email's
- * format / truncation / attachments matrix and modify_email's
- * labelIds + addLabelIds dedup merge (CR finding history).
+ * batch_modify_emails, batch_delete_emails, move_to_spam,
+ * move_to_spam_batch). Drives them through the full MCP roundtrip
+ * via InMemoryTransport so every branch in src/tools/messages.ts
+ * gets exercised — particularly read_email's format / truncation /
+ * attachments matrix, modify_email's labelIds + addLabelIds dedup
+ * merge (CR finding history), and the SPAM-only honesty note in the
+ * move_to_spam* responses (DD-001).
  */
 
 import { describe, it, expect, vi } from "vitest";
@@ -26,6 +28,7 @@ function makeMockGmail(opts: MockOpts = {}): {
   getSpy: ReturnType<typeof vi.fn>;
   listSpy: ReturnType<typeof vi.fn>;
   modifySpy: ReturnType<typeof vi.fn>;
+  batchModifySpy: ReturnType<typeof vi.fn>;
 } {
   const bodyText = opts.bodyText ?? "Hello from the test suite.";
   const threadId = opts.threadId ?? "T1";
@@ -38,6 +41,7 @@ function makeMockGmail(opts: MockOpts = {}): {
 
   const deleteSpy = vi.fn(() => Promise.resolve({ data: {} }));
   const modifySpy = vi.fn(() => Promise.resolve({ data: {} }));
+  const batchModifySpy = vi.fn(() => Promise.resolve({ data: {} }));
   const listSpy = vi.fn(() =>
     Promise.resolve({ data: { messages: [{ id: "M1" }, { id: "M2" }] } }),
   );
@@ -95,10 +99,11 @@ function makeMockGmail(opts: MockOpts = {}): {
         get: getSpy,
         list: listSpy,
         modify: modifySpy,
+        batchModify: batchModifySpy,
       },
     },
   } as unknown as gmail_v1.Gmail;
-  return { gmail, deleteSpy, getSpy, listSpy, modifySpy };
+  return { gmail, deleteSpy, getSpy, listSpy, modifySpy, batchModifySpy };
 }
 
 async function makeClient(gmail: gmail_v1.Gmail): Promise<{
@@ -307,6 +312,88 @@ describe("registerMessageTools — handler-level coverage", () => {
       // batch_delete uses different wording from batch_modify
       // ("deleted" vs "processed").
       expect(text).toMatch(/Successfully deleted: 2 messages/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("move_to_spam: applies SPAM label and emits the UI-only ML-feedback honesty note (DD-001)", async () => {
+    const { gmail, modifySpy } = makeMockGmail();
+    const { client, close } = await makeClient(gmail);
+    try {
+      const out = await client.callTool({
+        name: "move_to_spam",
+        arguments: { messageId: "M42" },
+      });
+      expect(modifySpy).toHaveBeenCalledTimes(1);
+      const call = modifySpy.mock.calls[0]?.[0] as {
+        userId: string;
+        id: string;
+        requestBody: { addLabelIds?: string[] };
+      };
+      expect(call.id).toBe("M42");
+      expect(call.requestBody.addLabelIds).toEqual(["SPAM"]);
+      const text = textOf(out as { content: Array<{ type: string; text?: string }> });
+      expect(text).toMatch(/moved to Spam/);
+      // The honesty disclaimer is the contract — DD-001 requires it.
+      expect(text).toMatch(/does NOT push a feedback signal/);
+      expect(text).toMatch(/anti-phishing ML classifier/);
+      expect(text).toMatch(/UI-only/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("move_to_spam_batch: applies SPAM via batchModify, chunks the ids, emits the honesty note", async () => {
+    const { gmail, batchModifySpy } = makeMockGmail();
+    const { client, close } = await makeClient(gmail);
+    try {
+      const out = await client.callTool({
+        name: "move_to_spam_batch",
+        arguments: { messageIds: ["A", "B", "C"], batchSize: 2 },
+      });
+      // 3 ids, batchSize 2 → 2 chunks (2 + 1).
+      expect(batchModifySpy).toHaveBeenCalledTimes(2);
+      const firstCall = batchModifySpy.mock.calls[0]?.[0] as {
+        requestBody: { ids: string[]; addLabelIds: string[] };
+      };
+      expect(firstCall.requestBody.ids).toEqual(["A", "B"]);
+      expect(firstCall.requestBody.addLabelIds).toEqual(["SPAM"]);
+      const text = textOf(out as { content: Array<{ type: string; text?: string }> });
+      expect(text).toMatch(/Successfully moved to Spam: 3 messages/);
+      expect(text).toMatch(/Does NOT trigger Google's anti-phishing/);
+      expect(text).toMatch(/UI-only/);
+    } finally {
+      await close();
+    }
+  });
+
+  it("move_to_spam_batch: surfaces per-chunk failures with the truncated-id list", async () => {
+    const batchModifySpy = vi.fn(() => Promise.reject(new Error("simulated batchModify failure")));
+    const gmail = {
+      users: {
+        messages: {
+          delete: vi.fn(),
+          get: vi.fn(),
+          list: vi.fn(),
+          modify: vi.fn(),
+          batchModify: batchModifySpy,
+        },
+      },
+    } as unknown as gmail_v1.Gmail;
+    const { client, close } = await makeClient(gmail);
+    try {
+      const out = await client.callTool({
+        name: "move_to_spam_batch",
+        arguments: {
+          messageIds: ["aaaaaaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbb"],
+        },
+      });
+      const text = textOf(out as { content: Array<{ type: string; text?: string }> });
+      expect(text).toMatch(/Failed to move: 2/);
+      expect(text).toContain("Failed message IDs");
+      expect(text).toContain("simulated batchModify failure");
+      expect(text).toMatch(/aaaaaaaaaaaaaaaa\.\.\./);
     } finally {
       await close();
     }

--- a/test/registrars.test.ts
+++ b/test/registrars.test.ts
@@ -3307,6 +3307,8 @@ describe("PR #3+#4+#5+#6 registrars — combined tools/list shape", () => {
           "list_inbox_threads",
           "modify_email",
           "modify_thread",
+          "move_to_spam",
+          "move_to_spam_batch",
           "pair_recipient",
           "read_email",
           "reply_all",


### PR DESCRIPTION
Implements the design decision recorded in `docs/DESIGN_DECISIONS.md` (DD-001).

## What's in this PR

### Documentation
- New file `docs/DESIGN_DECISIONS.md` with the klodr **maximalist posture** rationale and the first decision entry.

### DD-001 — `move_to_spam` instead of `report_phishing`

Upstream (`ArtyMcLabin/Gmail-MCP-Server`) ships a `report_phishing` tool whose implementation is `addLabelIds: ['SPAM']`. Gmail's UI 'Report phishing' button does two things: apply the SPAM label AND submit feedback to Google's ML anti-phishing classifier. The Gmail API only exposes step 1 — verified across Gmail API v1, Admin SDK Alert Center, Postmaster Tools, and Apps Script `moveToSpam`. A tool named `report_phishing` whose implementation does not actually report to Google's classifier is **misleading to an autonomous LLM**.

### Implementation

- `MoveToSpamSchema` + `MoveToSpamBatchSchema` in `src/tools.ts`
- 2 entries in `toolDefinitions` with explicit DO-NOT-USE warnings against treating these as 'report phishing'
- Handlers in `src/tools/messages.ts`: `gmail.users.messages.modify` for single, `gmail.users.messages.batchModify` for batch
- Response text includes the UI-only ML-feedback honesty disclaimer in every successful call

### Tests
- 3 new tests in `test/messages-handlers.test.ts`:
  - `move_to_spam` applies SPAM label + emits honesty note
  - `move_to_spam_batch` chunks correctly via `batchModify` + emits honesty note
  - `move_to_spam_batch` per-chunk failure rendering
- Mock gmail updated to include `batchModify` spy
- All 14 tests pass (11 existing + 3 new)

## Why this matters

The honesty disclaimer is the **contract** with the LLM. A future change that removes it would silently let an LLM believe it is contributing to anti-phishing detection when it isn't. The DD-001 entry exists so a future maintainer (human or LLM) knows why this is required.