### PR TITLE
ci(leak-detect): bump reusable to skip bot-authored PRs

### DIFF
--- a/.github/workflows/leak-detect.yml
+++ b/.github/workflows/leak-detect.yml
@@ -27,6 +27,6 @@ jobs:
     # fail as a required check. Leak scanning of fork PRs is enforced
     # post-merge by the maintainer-side push trigger on main.
     if: github.event.pull_request.head.repo.full_name == github.repository
-    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@7987f59050ff9ee614d21b603e4ba87ace27f7d9
+    uses: klodr/.github/.github/workflows/reusable-leak-detect.yml@33ff8e518ecb7a799f114dc83ba06c9f0d660845
     secrets:
       leak-detect-app-private-key: ${{ secrets.LEAK_DETECT_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Picks up klodr/.github#39 (`33ff8e51`) — leak-detect scan now skips when `endsWith(github.actor, '[bot]')`, so Dependabot bumps and `klodr-release-please[bot]` PRs merge without needing a manual ruleset bypass. Human PRs unchanged.