### PR TITLE
fix(downloads): accept long Gmail attachment IDs

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,6 +11,15 @@ const GmailIdSchema = z
   .max(256)
   .regex(/^[A-Za-z0-9_-]+$/);
 
+// Gmail *attachment* IDs share the base64url charset but encode the
+// message + MIME part path, so real ones routinely run 300-600+ chars
+// (#222). Same forged-ID rationale as GmailIdSchema, higher ceiling.
+const AttachmentIdSchema = z
+  .string()
+  .min(1)
+  .max(2048)
+  .regex(/^[A-Za-z0-9_-]+$/);
+
 // User-supplied filesystem paths. The attachment jail in `src/utl.ts`
 // (assertAttachmentPathAllowed) is the load-bearing check at runtime,
 // but a schema-level guard rejects the worst shapes before Zod would
@@ -361,7 +370,7 @@ export const CreateFilterFromTemplateSchema = z
 
 export const DownloadAttachmentSchema = z.object({
   messageId: GmailIdSchema.describe("ID of the email message containing the attachment"),
-  attachmentId: GmailIdSchema.describe("ID of the attachment to download"),
+  attachmentId: AttachmentIdSchema.describe("ID of the attachment to download"),
   filename: z
     .string()
     .optional()

--- a/src/tools/downloads.ts
+++ b/src/tools/downloads.ts
@@ -160,7 +160,7 @@ export function registerDownloadTools(
 
           const findAttachment = (part: GmailMessagePart): string | null => {
             if (part.body && part.body.attachmentId === args.attachmentId) {
-              return part.filename || `attachment-${args.attachmentId}`;
+              return part.filename || `attachment-${args.attachmentId.slice(0, 24)}`;
             }
             if (part.parts) {
               for (const subpart of part.parts) {
@@ -173,7 +173,7 @@ export function registerDownloadTools(
 
           filename =
             (messageResponse.data.payload ? findAttachment(messageResponse.data.payload) : null) ||
-            `attachment-${args.attachmentId}`;
+            `attachment-${args.attachmentId.slice(0, 24)}`;
         }
 
         // Sanitize filename: backslash / NUL / C0 / control chars from
@@ -190,7 +190,7 @@ export function registerDownloadTools(
            future sanitize change that returns "" or "." instead
            of "attachment". */
         if (filename === "" || filename === ".") {
-          filename = `attachment-${args.attachmentId}`;
+          filename = `attachment-${args.attachmentId.slice(0, 24)}`;
         }
         /* v8 ignore stop */
 

--- a/test/registrars.test.ts
+++ b/test/registrars.test.ts
@@ -2614,6 +2614,26 @@ describe("PR #6 registrars — download error paths", () => {
     });
   });
 
+  it("download_attachment accepts 400-char attachment IDs and truncates the fallback name (#222)", async () => {
+    // Real Gmail attachment IDs encode the message + MIME part path and
+    // routinely exceed 256 chars; the derived-name fallback must not
+    // overflow the OS filename limit (ENAMETOOLONG).
+    const longId = "A".repeat(400);
+    await withFix(["gmail.modify"], async (fix) => {
+      const result = (await fix.client.callTool({
+        name: "download_attachment",
+        arguments: {
+          messageId: "msg_with_att",
+          attachmentId: longId,
+          savePath: downloadDir,
+        },
+      })) as { content: Array<{ type: string; text: string }>; isError?: boolean };
+      expect(result.isError).toBeFalsy();
+      const written = readdirSync(downloadDir);
+      expect(written).toContain(`attachment-${longId.slice(0, 24)}`);
+    });
+  });
+
   it("download_attachment surfaces a clear error when Gmail returns empty data", async () => {
     // Pin the "No attachment data received" guard at
     // `src/tools/downloads.ts:125-127`. Gmail returns an empty


### PR DESCRIPTION
Fixes #222 — les deux bugs du rapport :
1. `attachmentId` avait le plafond 256 de `GmailIdSchema` ; les IDs d'attachment réels (message + chemin MIME encodés) font couramment 300-600+ caractères → schéma dédié `AttachmentIdSchema` (base64url, ≤2048).
2. Le fallback de nom `attachment-${id}` dépassait la limite de nom de fichier de l'OS (ENAMETOOLONG) → tronqué à 24 caractères (3 occurrences).

Test ajouté : ID de 400 caractères accepté + nom de fallback tronqué. 785 tests verts.