### PR TITLE
ci(release): publish to npm via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -243,8 +243,8 @@ jobs:
       # Trusted publishing: npm mints short-lived credentials from the
       # workflow's OIDC identity (registered on npmjs.com for this repo +
       # workflow file). No NPM_TOKEN secret; provenance stays on.
-      - name: Update npm (trusted publishing needs >= 11.5.1)
-        run: npm install -g npm@latest
+      - name: Pin npm 11.18.0 (trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@11.18.0
 
       - name: Publish to npm
         run: npm publish --access public --provenance --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,9 @@ jobs:
         with:
           node-version: "22"
           cache: "npm"
-          registry-url: "https://registry.npmjs.org"
+          # No registry-url: setup-node would write an npm auth line
+          # reading NODE_AUTH_TOKEN, which (left empty) makes npm take
+          # the classic-auth path instead of the OIDC exchange.
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,7 +240,11 @@ jobs:
           npm pkg delete scripts.prepare || true
           npm pkg delete scripts.prepublishOnly || true
 
+      # Trusted publishing: npm mints short-lived credentials from the
+      # workflow's OIDC identity (registered on npmjs.com for this repo +
+      # workflow file). No NPM_TOKEN secret; provenance stays on.
+      - name: Update npm (trusted publishing needs >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Publish to npm
         run: npm publish --access public --provenance --ignore-scripts
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Remplace le secret `NPM_TOKEN` (expirant — cause de l'échec du publish v1.3.0) par le **trusted publishing OIDC** : npm émet des credentials éphémères à partir de l'identité du workflow, enregistrée sur npmjs.com (repo `klodr/gmail-mcp`, workflow `release.yml`). npm ≥ 11.5.1 requis sur le runner (step de mise à jour ajouté). `id-token: write` déjà en place. Prérequis : configurer le Trusted Publisher côté npmjs.com avant le prochain tag.