### PR TITLE
chore(release): document OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,9 @@ name: Release & npm publish
 
 # Triggered by `git push origin vX.Y.Z`. Creates the GitHub Release from the
 # matching CHANGELOG.md section, signs the build artifact with Sigstore, then
-# publishes to npm with provenance. End-to-end, no manual UI step.
+# publishes to npm with provenance via OIDC trusted publishing (no token:
+# the npmjs.com trusted-publisher entry for this repo + workflow file is
+# the credential). End-to-end, no manual UI step.
 on:
   push:
     tags:


### PR DESCRIPTION
Documente le trusted publishing dans l'en-tête du workflow, et porte le footer ci-dessous pour que release-please coupe **1.3.1** — le tag v1.3.0 pointe la définition pré-OIDC (token expiré), donc la publication npm doit repartir d'un tag incluant la bascule. npm passera 1.2.0 → 1.3.1 (contenu de 1.3.0 inclus).

Release-As: 1.3.1