### PR TITLE
ci(release): run publish on Node 24 (bundled npm 11.16, OIDC-ready)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6.0.0
 
-      - name: Setup Node 22
+      - name: Setup Node 24
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          # Node 24 ships npm >= 11.5.1, which supports OIDC trusted
+          # publishing out of the box (no global npm install needed).
+          node-version: "24"
           cache: "npm"
           # No registry-url: setup-node would write an npm auth line
           # reading NODE_AUTH_TOKEN, which (left empty) makes npm take
@@ -247,8 +249,5 @@ jobs:
       # Trusted publishing: npm mints short-lived credentials from the
       # workflow's OIDC identity (registered on npmjs.com for this repo +
       # workflow file). No NPM_TOKEN secret; provenance stays on.
-      - name: Pin npm 11.18.0 (trusted publishing needs >= 11.5.1)
-        run: npm install -g npm@11.18.0
-
       - name: Publish to npm
         run: npm publish --access public --provenance --ignore-scripts

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,8 @@ jobs:
           # Node 24 ships npm >= 11.5.1, which supports OIDC trusted
           # publishing out of the box (no global npm install needed).
           node-version: "24"
-          cache: "npm"
+          # No npm cache here: keep the publish job's environment minimal
+          # for OIDC trusted publishing (per CodeRabbit review).
           # No registry-url: setup-node would write an npm auth line
           # reading NODE_AUTH_TOKEN, which (left empty) makes npm take
           # the classic-auth path instead of the OIDC exchange.


### PR DESCRIPTION
Résout l'alerte Scorecard **Pinned-Dependencies #41** (`npm install -g npm@11.18.0` non épinglé par hash).

Node 24 embarque **npm 11.16.0** (≥ 11.5.1 requis pour l'OIDC trusted publishing), donc le step d'install global n'est plus nécessaire — retiré. Le job build/test reste sur Node 22. `engines.node >= 22.23.1` → build sur Node 24 OK.